### PR TITLE
Major updates and bug fixes in green-impurity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(GREEN-ED C CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 ################GREEN RELEASE VERSION####################
-set(GREEN_RELEASE origin/main CACHE STRING "Release version for Green dependencies")
+set(GREEN_RELEASE "v0.3.2" CACHE STRING "Release version for Green dependencies")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(GreenDeps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,15 @@ project(GREEN-ED C CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 ################GREEN RELEASE VERSION####################
-set(GREEN_RELEASE origin/main)
+set(GREEN_RELEASE origin/main CACHE STRING "Release version for Green dependencies")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(GreenDeps)
 
+add_green_dependency(green-utils)
 add_green_dependency(green-ndarray)
 add_green_dependency(green-symmetry)
 add_green_dependency(green-grids)
-add_green_dependency(green-utils)
 find_package(Eigen3 REQUIRED)
 
 add_subdirectory(deps)

--- a/cmake/GreenDeps.cmake
+++ b/cmake/GreenDeps.cmake
@@ -3,6 +3,7 @@ function(add_green_dependency TARGET)
     FetchContent_Declare(${TARGET} GIT_REPOSITORY 
                          https://github.com/Green-Phys/${TARGET}.git
                          GIT_TAG ${GREEN_RELEASE} # or a later release
+                         CMAKE_ARGS -DGREEN_RELEASE=${GREEN_RELEASE}
                         )
 
     FetchContent_MakeAvailable(${TARGET})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_library(impurity gw_impurity_solver.cpp)
+add_library(impurity
+    bath_fitting.cpp
+    ed_impurity_solver.cpp
+    inchworm_impurity_solver.cpp
+    gw_impurity_solver.cpp
+    impurity_solver.cpp
+)
 target_include_directories(impurity PUBLIC .)
 target_link_libraries(impurity PUBLIC GREEN::NDARRAY GREEN::UTILS GREEN::GRIDS GREEN::SYMMETRY lsqcpp::lsqcpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-project(impurity)
-
-add_library(impurity INTERFACE)
-include_directories(.)
-target_include_directories(impurity INTERFACE .)
-target_link_libraries(impurity INTERFACE GREEN::NDARRAY GREEN::UTILS GREEN::GRIDS GREEN::SYMMETRY lsqcpp::lsqcpp)
+add_library(impurity gw_impurity_solver.cpp)
+target_include_directories(impurity PUBLIC .)
+target_link_libraries(impurity PUBLIC GREEN::NDARRAY GREEN::UTILS GREEN::GRIDS GREEN::SYMMETRY lsqcpp::lsqcpp)

--- a/src/bath_fitting.cpp
+++ b/src/bath_fitting.cpp
@@ -8,6 +8,7 @@ namespace green::impurity {
   ztensor<4> compute_hyb_fun(const ztensor<1>& freqs, const dtensor<2>& bath, const itensor<1>& bath_structure, size_t ns,
                               size_t nio) {
     ztensor<4> hyb(freqs.size(), ns, nio, nio);
+    hyb.set_zero();
     for (size_t iw = 0; iw < freqs.size(); ++iw) {
       for (size_t is = 0; is < ns; ++is) {
         size_t shift = 0;

--- a/src/bath_fitting.cpp
+++ b/src/bath_fitting.cpp
@@ -1,0 +1,63 @@
+#include <green/impurity/bath_fitting.h>
+
+#include <iostream>
+#include <numeric>
+
+namespace green::impurity {
+
+  ztensor<4> compute_hyb_fun(const ztensor<1>& freqs, const dtensor<2>& bath, const itensor<1>& bath_structure, size_t ns,
+                              size_t nio) {
+    ztensor<4> hyb(freqs.size(), ns, nio, nio);
+    for (size_t iw = 0; iw < freqs.size(); ++iw) {
+      for (size_t is = 0; is < ns; ++is) {
+        size_t shift = 0;
+        for (size_t io = 0; io < nio; ++io) {
+          size_t nk = bath_structure(io);
+          size_t ik = bath_structure(io) * 2;
+          for (size_t i = 0; i < nk; ++i)
+            hyb(iw, is, io, io) += (bath(is, shift + i) * bath(is, shift + i)) / (freqs(iw) - bath(is, shift + nk + i));
+          shift += ik;
+        }
+      }
+    }
+    return hyb;
+  }
+
+  std::pair<ztensor<4>, dtensor<2>> minimize(const ztensor<1>& freqs, const ztensor<4>& hyb_fun,
+                                              const dtensor<2>& initial_guess, const itensor<1>& bath_structure,
+                                              int type) {
+    size_t     ns = hyb_fun.shape()[1];
+    dtensor<2> res(ns, std::reduce(bath_structure.begin(), bath_structure.end()) * 2);
+    for (size_t is = 0; is < hyb_fun.shape()[1]; ++is) {
+      std::cout << "spin " << is << std::endl;
+      size_t shift = 0;
+      for (size_t io = 0; io < hyb_fun.shape()[3]; ++io) {
+        std::cout << "orbital " << io << std::endl;
+        lsqcpp::GaussNewtonX<double, hybridization_function_error, lsqcpp::DoglegMethod> optimizer;
+        optimizer.setMaximumIterations(40000);
+        optimizer.setMinimumGradientLength(1e-8);
+        optimizer.setMinimumStepLength(1e-9);
+        optimizer.setMinimumError(1e-14);
+        optimizer.setRefinementParameters({1.0, 3.0, 1e-6, 0.001, 100});
+        optimizer.setVerbosity(0);
+        size_t                       ik = bath_structure(io) * 2;
+        hybridization_function_error function_error(freqs, hyb_fun, bath_structure, io, is, type);
+        optimizer.setObjective(function_error);
+        Eigen::VectorXd initialGuess(ik);
+        for (size_t i = 0; i < ik; ++i) initialGuess(i) = initial_guess(is, i + shift);
+        std::cout << "Initial guess: " << initialGuess.transpose() << std::endl;
+        auto result = optimizer.minimize(initialGuess);
+        std::cout << "Done! Converged: " << (result.converged ? "true" : "false") << " Iterations: " << result.iterations
+                  << std::endl;
+        std::cout << "Final fval: " << result.fval.transpose() << std::endl;
+        std::cout << "Final xval: " << result.xval.transpose() << std::endl;
+        std::copy(result.xval.data(), result.xval.data() + result.xval.size(), res(is).begin() + shift);
+        std::transform(res(is).begin() + shift, res(is).begin() + shift + bath_structure(io), res(is).begin() + shift,
+                       [](double x) { return std::abs(x); });
+        shift += ik;
+      }
+    }
+    return std::make_pair(compute_hyb_fun(freqs, res, bath_structure, hyb_fun.shape()[1], hyb_fun.shape()[2]), res);
+  }
+
+}  // namespace green::impurity

--- a/src/ed_impurity_solver.cpp
+++ b/src/ed_impurity_solver.cpp
@@ -1,5 +1,6 @@
 #include <green/impurity/ed_impurity_solver.h>
 
+#include <filesystem>
 #include <fstream>
 #include <numeric>
 

--- a/src/ed_impurity_solver.cpp
+++ b/src/ed_impurity_solver.cpp
@@ -1,0 +1,170 @@
+#include <green/impurity/ed_impurity_solver.h>
+
+#include <fstream>
+#include <numeric>
+
+namespace green::impurity {
+
+  ed_impurity_solver::ed_impurity_solver(const std::string& input_file, const std::string& bath_file,
+                                         const std::string& impurity_solver_exec, const std::string& impurity_solver_params,
+                                         const std::string& root) :
+      _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
+      _root(root) {
+    size_t        nimp;
+    h5pp::archive ar(input_file, "r");
+    ar["nimp"] >> nimp;
+    ar.close();
+    if (!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
+    std::ifstream ff(bath_file);
+    for (size_t imp = 0; imp < nimp; ++imp) {
+      std::vector<double> bath;
+      std::vector<int>    bath_structure;
+      size_t              nio, nbo;
+      ff >> nio >> nbo;
+      for (size_t io = 0; io < nio; ++io) {
+        int nb_io;
+        ff >> nb_io;
+        bath_structure.push_back(nb_io);
+      }
+      for (size_t bo = 0; bo < nbo * 2; ++bo) {
+        double b;
+        ff >> b;
+        bath.push_back(b);
+      }
+      // Store single-spin template; tiling to actual ns happens in solve()
+      dtensor<2> initial_bath(1, bath.size());
+      itensor<1> bath_struct(bath_structure.size());
+      std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
+      std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
+      _initial_bath.push_back(initial_bath);
+      _bath_structure.push_back(bath_struct);
+    }
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> ed_impurity_solver::solve(size_t imp_n, const grids::transformer_t& ft, double mu,
+                                                                const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                                                const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                                                const dtensor<4>& interaction, const ztensor<4>& g_w) const {
+    ztensor<3> sigma_inf_new(delta_1.shape());
+    ztensor<4> sigma_new(delta_w.shape());
+    size_t     ns    = ovlp.shape()[0];
+    size_t     nbath = _initial_bath[imp_n].shape()[1];
+    dtensor<2> initial_bath_tiled(ns, nbath);
+    for (size_t is = 0; is < ns; ++is)
+      std::copy(_initial_bath[imp_n](0).begin(), _initial_bath[imp_n](0).end(), initial_bath_tiled(is).begin());
+    auto [delta_out, bath_arr] =
+        minimize(ft.sd().repn_fermi().wsample() * 1.0i, delta_w, initial_bath_tiled, _bath_structure[imp_n], 1);
+    {
+      std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
+      for (auto b : bath_arr) {
+        ofile << b << " ";
+      }
+      ofile << std::endl;
+    }
+    size_t                  nio = ovlp.shape()[2];
+    size_t                  nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
+    dtensor<2>              Epsk(nb, ns);
+    std::vector<dtensor<2>> Vk;
+    for (size_t is = 0; is < ns; ++is) {
+      for (size_t io = 0, ik = 0, shift = 0; io < nio; ++io) {
+        size_t nk = _bath_structure[imp_n](io);
+        for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+          Epsk(ik, is) = bath_arr(is, shift + nk + iik);
+        }
+        shift += 2 * nk;
+      }
+    }
+    for (size_t io = 0; io < nio; ++io) {
+      dtensor<2> Vk_(Epsk.shape());
+      for (size_t io2 = 0, ik = 0, shift = 0; io2 < nio; io2++) {
+        size_t nk = _bath_structure[imp_n](io2);
+        for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+          for (size_t is = 0; is < ns; ++is) {
+            if (io == io2) Vk_(ik, is) = bath_arr(is, shift + iik);
+          }
+        }
+        shift += 2 * nk;
+      }
+      Vk.push_back(Vk_);
+    }
+    ztensor<4> g0_imp(delta_out.shape());
+    for (size_t iw = 0; iw < delta_out.shape()[0]; ++iw) {
+      for (size_t is = 0; is < ns; ++is) {
+        auto g_inv_w_imp =
+            matrix(ovlp(is)) * (ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(hcore_eff(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
+        auto xxx               = g_inv_w_imp.inverse().eval();
+        matrix(g0_imp(iw, is)) = xxx;
+      }
+    }
+    {
+      h5pp::archive data(_root + "/ed." + std::to_string(imp_n) + ".input.h5", "w");
+      data["freq"] << ft.wsample_fermi();
+      data["G0_imp/data"] << g0_imp.view<double>();
+      data["G_imp/data"] << g_w;
+      data["Delta/data"] << delta_out;
+      data["Delta/data_in"] << delta_w;
+      data["Delta/static"] << delta_1;
+
+      itensor<2> sectors(1, 2);
+      sectors(0, 0) = 0;
+      sectors(0, 1) = 0;
+      auto hop_g    = data["sectors"];
+      hop_g["values"] << sectors;
+      auto bath   = data["Bath"];
+      // Post process H0->H0_imp
+      auto H0_imp = ndarray::transpose(hcore_eff + delta_1, "sij->ijs").astype<double>();
+
+      bath["Epsk/values"] << Epsk;
+      for (size_t io = 0; io < nio; ++io) {
+        bath["Vk_" + std::to_string(io) + "/values"] << Vk[io];
+        data["H0_" + std::to_string(io) + "/values"] << H0_imp(io);
+      }
+      dtensor<6> interaction_(2, 2, nio, nio, nio, nio);
+
+      // transform interaction into physics convention
+      auto interaction_phys = ndarray::transpose(interaction, "ijkl->ikjl");
+
+      interaction_(0, 0) << interaction_phys;
+      interaction_(0, 1) << interaction_phys;
+      interaction_(1, 0) << interaction_phys;
+      interaction_(1, 1) << interaction_phys;
+      data["interaction/values"] << interaction_;
+      data["mu"] << mu;
+      if (nio > 1) {
+        // Store the list of ordered orbital pairs for which G(io, jo) should be calculated
+        // NOTE: Diagonal part of G is handled differently
+        itensor<2> orbitals(nio * nio - nio, 2);
+        for (size_t io = 0, iii = 0; io < nio; ++io) {
+          for (size_t jo = 0; jo < nio; ++jo) {
+            if (io != jo) {
+              orbitals(iii, 0) = io;
+              orbitals(iii, 1) = jo;
+              ++iii;
+            }
+          }
+        }
+        data["GreensFunction_orbitals/values"] << orbitals;
+      }
+      data.close();
+    }
+    std::string run = (_impurity_solver_exec + " " + _impurity_solver_params + " --NSITES=" + std::to_string(nio + nb) +
+                       " --NSPINS=" + std::to_string(2) + " --INPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) +
+                       ".input.h5" + " --OUTPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) + ".result.h5" +
+                       " --arpack.SECTOR=false --siam.NORBITALS=" + std::to_string(nio) +
+                       " --spinstorage.ORBITAL_NUMBER=" + std::to_string(nio) +
+                       " --lanc.BETA=" + std::to_string(ft.sd().beta()));
+    int sysresult = std::system(run.c_str());
+    if (std::filesystem::exists(_root + "/ed." + std::to_string(imp_n) + ".result.h5")) {
+      h5pp::archive ar(_root + "/ed." + std::to_string(imp_n) + ".result.h5", "r");
+      dtensor<3>    xxx;
+      ar["results/Sigma_inf_ij"] >> xxx;
+      sigma_inf_new.resize(xxx.shape());
+      sigma_inf_new << xxx;
+      ar["results/Sigma_ij"] >> sigma_new.view<double>();
+    } else {
+      std::cerr << "Impurity result file has not been found" << std::endl;
+    }
+    return std::make_tuple(sigma_inf_new, sigma_new);
+  }
+
+}  // namespace green::impurity

--- a/src/ed_impurity_solver.cpp
+++ b/src/ed_impurity_solver.cpp
@@ -1,3 +1,4 @@
+#include <green/impurity/bath_fitting.h>
 #include <green/impurity/ed_impurity_solver.h>
 
 #include <filesystem>
@@ -155,6 +156,9 @@ namespace green::impurity {
                        " --spinstorage.ORBITAL_NUMBER=" + std::to_string(nio) +
                        " --lanc.BETA=" + std::to_string(ft.sd().beta()));
     int sysresult = std::system(run.c_str());
+    if (sysresult != 0) {
+      throw impurity_solver_exec_error("ED impurity child process failed with code " + std::to_string(sysresult));
+    }
     if (std::filesystem::exists(_root + "/ed." + std::to_string(imp_n) + ".result.h5")) {
       h5pp::archive ar(_root + "/ed." + std::to_string(imp_n) + ".result.h5", "r");
       dtensor<3>    xxx;
@@ -163,7 +167,7 @@ namespace green::impurity {
       sigma_inf_new << xxx;
       ar["results/Sigma_ij"] >> sigma_new.view<double>();
     } else {
-      std::cerr << "Impurity result file has not been found" << std::endl;
+      throw impurity_result_not_found("ED impurity result file not found: " + _root + "/ed." + std::to_string(imp_n) + ".result.h5");
     }
     return std::make_tuple(sigma_inf_new, sigma_new);
   }

--- a/src/green/impurity/bath_fitting.h
+++ b/src/green/impurity/bath_fitting.h
@@ -147,24 +147,8 @@ namespace green::impurity {
    * @param ns - number of spins
    * @param nio - number of impurity orbitals
    */
-  inline ztensor<4> compute_hyb_fun(const ztensor<1>& freqs, const dtensor<2>& bath, const itensor<1>& bath_structure, size_t ns,
-                                    size_t nio) {
-    ztensor<4> hyb(freqs.size(), ns, nio, nio);
-    size_t     nb = 2 * std::reduce(bath_structure.begin(), bath_structure.end());
-    for (size_t iw = 0; iw < freqs.size(); ++iw) {
-      for (size_t is = 0; is < ns; ++is) {
-        size_t shift = 0;
-        for (size_t io = 0; io < nio; ++io) {
-          size_t nk = bath_structure(io);
-          size_t ik = bath_structure(io) * 2;
-          for (size_t i = 0; i < nk; ++i)
-            hyb(iw, is, io, io) += (bath(is, shift + i) * bath(is, shift + i)) / (freqs(iw) - bath(is, shift + nk + i));
-          shift += ik;
-        }
-      }
-    }
-    return hyb;
-  }
+  ztensor<4> compute_hyb_fun(const ztensor<1>& freqs, const dtensor<2>& bath, const itensor<1>& bath_structure, size_t ns,
+                             size_t nio);
 
   /**
    * For a given Hybridization function defiend on Matsubara frequency grid find discrete approximation and
@@ -176,72 +160,9 @@ namespace green::impurity {
    * @param bath_structure 1d array with numbers of bath sites for each orbitals
    * @return Discretized approximation of the Hybridization function and corresponding bath parameters
    */
-  inline std::pair<ztensor<4>, dtensor<2>> minimize(const ztensor<1>& freqs, const ztensor<4>& hyb_fun,
-                                                    const dtensor<2>& initial_guess, const itensor<1>& bath_structure,
-                                                    int type = 3) {
-    size_t     ns = hyb_fun.shape()[1];
-    dtensor<2> res(ns, std::reduce(bath_structure.begin(), bath_structure.end()) * 2);
-    for (size_t is = 0; is < hyb_fun.shape()[1]; ++is) {
-      std::cout << "spin " << is << std::endl;
-      size_t shift = 0;
-      for (size_t io = 0; io < hyb_fun.shape()[3]; ++io) {
-        std::cout << "orbital " << io << std::endl;
-        // Create GaussNewton optimizer with dogleg method
-        lsqcpp::GaussNewtonX<double, hybridization_function_error, lsqcpp::DoglegMethod> optimizer;
-        // lsqcpp::LevenbergMarquardtX<double, hybridization_function_error> optimizer;
-        // Set number of iterations as stop criterion.
-        // Set it to 0 or negative for infinite iterations (default is 0).
-        optimizer.setMaximumIterations(40000);
-        // Set the minimum length of the gradient.
-        // The optimizer stops minimizing if the gradient length falls below this
-        // value.
-        // Set it to 0 or negative to disable this stop criterion (default is 1e-9).
-        optimizer.setMinimumGradientLength(1e-8);
-        // Set the minimum length of the step.
-        // The optimizer stops minimizing if the step length falls below this
-        // value.
-        // Set it to 0 or negative to disable this stop criterion (default is 1e-9).
-        optimizer.setMinimumStepLength(1e-9);
-        // Set the minimum least squares error.
-        // The optimizer stops minimizing if the error falls below this
-        // value.
-        // Set it to 0 or negative to disable this stop criterion (default is 0).
-        optimizer.setMinimumError(1e-14);
-        // Set the parameters of the step refiner (Dogleg Method).
-        optimizer.setRefinementParameters({1.0, 3.0, 1e-6, 0.001, 100});
-        // optimizer.setRefinementParameters({0.001});
-
-        // Turn verbosity on, so the optimizer prints status updates after each
-        // iteration.
-        optimizer.setVerbosity(0);
-        size_t                       ik = bath_structure(io) * 2;
-        hybridization_function_error function_error(freqs, hyb_fun, bath_structure, io, is, type);
-        optimizer.setObjective(function_error);
-        // Set initial guess.
-        Eigen::VectorXd initialGuess(ik);
-        for (size_t i = 0; i < ik; ++i) initialGuess(i) = initial_guess(is, i + shift);
-
-        std::cout << "Initial guess: " << initialGuess.transpose() << std::endl;
-        // Start the optimization.
-        auto result = optimizer.minimize(initialGuess);
-
-        std::cout << "Done! Converged: " << (result.converged ? "true" : "false") << " Iterations: " << result.iterations
-                  << std::endl;
-
-        // do something with final function value
-        std::cout << "Final fval: " << result.fval.transpose() << std::endl;
-
-        // do something with final x-value
-        std::cout << "Final xval: " << result.xval.transpose() << std::endl;
-        std::copy(result.xval.data(), result.xval.data() + result.xval.size(), res(is).begin() + shift);
-        std::transform(res(is).begin() + shift, res(is).begin() + shift + bath_structure(io), res(is).begin() + shift,
-                       [](double x) { return std::abs(x); });
-        shift += ik;
-      }
-    }
-    compute_hyb_fun(freqs, res, bath_structure, hyb_fun.shape()[1], hyb_fun.shape()[2]);
-    return std::make_pair(compute_hyb_fun(freqs, res, bath_structure, hyb_fun.shape()[1], hyb_fun.shape()[2]), res);
-  }
+  std::pair<ztensor<4>, dtensor<2>> minimize(const ztensor<1>& freqs, const ztensor<4>& hyb_fun,
+                                             const dtensor<2>& initial_guess, const itensor<1>& bath_structure,
+                                             int type = 3);
 
 }  // namespace green::impurity
 

--- a/src/green/impurity/bath_fitting.h
+++ b/src/green/impurity/bath_fitting.h
@@ -73,6 +73,8 @@ namespace green::impurity {
      * @param delta - Hybridization function
      * @param bath_structure - structure of the bath for `io`-th orbital
      * @param io - number of current orbital to minimize
+     * @param is - current spin channel to minimize
+     * @param type - type of cost function to use: 1 - sum of residuals, 2 - max residual, 3 - max residual with no frequency cutoff
      */
     hybridization_function_error(const ztensor<1>& freqs, const ztensor<4>& delta, const itensor<1>& bath_structure, size_t io,
                                  size_t is, int type = 3) :

--- a/src/green/impurity/bath_fitting.h
+++ b/src/green/impurity/bath_fitting.h
@@ -22,20 +22,11 @@
 #ifndef GREEN_ED_BATH_FITTING_H
 #define GREEN_ED_BATH_FITTING_H
 
-#include <green/ndarray/ndarray.h>
-#include <green/ndarray/ndarray_math.h>
-
-#include <complex>
 #include <lsqcpp/lsqcpp.hpp>
 
-namespace green::impurity {
+#include "common_defs.h"
 
-  template <size_t N>
-  using ztensor = green::ndarray::ndarray<std::complex<double>, N>;
-  template <size_t N>
-  using dtensor = green::ndarray::ndarray<double, N>;
-  template <size_t N>
-  using itensor = green::ndarray::ndarray<int, N>;
+namespace green::impurity {
 
   template <typename T, size_t D>
   std::array<size_t, D + 1> operator+(const std::array<size_t, D>& a, T b) {

--- a/src/green/impurity/common_defs.h
+++ b/src/green/impurity/common_defs.h
@@ -1,0 +1,47 @@
+#ifndef GREEN_IMPURITY_COMMON_DEFS_H
+#define GREEN_IMPURITY_COMMON_DEFS_H
+
+#include <Eigen/Dense>
+#include <green/params/params.h>
+#include <green/utils/mpi_shared.h>
+
+#include <tuple>
+#include <green/ndarray/ndarray_math.h>
+#include <green/grids/transformer_t.h>
+#include <green/symmetry/symmetry.h>
+
+namespace green::impurity {
+  template <size_t N>
+  using ztensor = ndarray::ndarray<std::complex<double>, N>;
+  template <size_t N>
+  using dtensor = ndarray::ndarray<double, N>;
+  template <size_t N>
+  using itensor    = ndarray::ndarray<int, N>;
+  using bz_utils_t = symmetry::brillouin_zone_utils<symmetry::inv_symm_op>;
+
+  template <typename prec>
+  using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  template <typename prec>
+  using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  template <typename prec, typename = std::enable_if_t<std::is_same_v<prec, std::remove_const_t<prec>>>>
+  auto matrix(ndarray::ndarray<prec, 2>&& array) {
+    return MMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);
+  }
+
+  template <typename prec>
+  auto matrix(const ndarray::ndarray<const prec, 2>& array) {
+    return CMMatrixX<prec>(const_cast<prec*>(array.data()), array.shape()[0], array.shape()[1]);
+  }
+
+  template <typename prec>
+  auto matrix(ndarray::ndarray<const prec, 2>&& array) {
+    return CMMatrixX<prec>(const_cast<prec*>(array.data()), array.shape()[0], array.shape()[1]);
+  }
+
+  template <typename prec>
+  auto matrix(const ndarray::ndarray<prec, 2>& array) {
+    return CMMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);
+  }
+}
+
+#endif // GREEN_IMPURITY_COMMON_DEFS_H

--- a/src/green/impurity/common_defs.h
+++ b/src/green/impurity/common_defs.h
@@ -1,14 +1,19 @@
 #ifndef GREEN_IMPURITY_COMMON_DEFS_H
 #define GREEN_IMPURITY_COMMON_DEFS_H
 
-#include <Eigen/Dense>
-#include <green/params/params.h>
-#include <green/utils/mpi_shared.h>
-
+#include <array>
+#include <complex>
+#include <functional>
+#include <string>
 #include <tuple>
-#include <green/ndarray/ndarray_math.h>
+#include <utility>
+
+#include <Eigen/Dense>
 #include <green/grids/transformer_t.h>
+#include <green/ndarray/ndarray_math.h>
+#include <green/params/params.h>
 #include <green/symmetry/symmetry.h>
+#include <green/utils/mpi_shared.h>
 
 namespace green::impurity {
   template <size_t N>

--- a/src/green/impurity/common_defs.h
+++ b/src/green/impurity/common_defs.h
@@ -1,21 +1,29 @@
 #ifndef GREEN_IMPURITY_COMMON_DEFS_H
 #define GREEN_IMPURITY_COMMON_DEFS_H
 
-#include <array>
 #include <complex>
-#include <functional>
 #include <string>
-#include <tuple>
-#include <utility>
+#include <type_traits>
 
 #include <Eigen/Dense>
+#include "except.h"
+
 #include <green/grids/transformer_t.h>
 #include <green/ndarray/ndarray_math.h>
-#include <green/params/params.h>
 #include <green/symmetry/symmetry.h>
-#include <green/utils/mpi_shared.h>
 
 namespace green::impurity {
+
+  enum class impurity_solver_type { ED, INCHWORM, GW };
+
+  inline impurity_solver_type parse_impurity_solver_type(const std::string& s) {
+    if (s == "ED") return impurity_solver_type::ED;
+    if (s == "INCHWORM") return impurity_solver_type::INCHWORM;
+    if (s == "GW") return impurity_solver_type::GW;
+    throw incorr_impurity_solver_type("Unknown impurity_solver type '" + s +
+                                      "'. Valid options are: ED, INCHWORM, GW.");
+  }
+
   template <size_t N>
   using ztensor = ndarray::ndarray<std::complex<double>, N>;
   template <size_t N>

--- a/src/green/impurity/common_defs.h
+++ b/src/green/impurity/common_defs.h
@@ -20,9 +20,13 @@ namespace green::impurity {
   using bz_utils_t = symmetry::brillouin_zone_utils<symmetry::inv_symm_op>;
 
   template <typename prec>
-  using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using MMatrixX   = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using MMatrixXcd = Eigen::Map<Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using MMatrixXd  = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
   template <typename prec>
-  using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using CMMatrixX   = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using CMMatrixXcd = Eigen::Map<const Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using CMMatrixXd  = Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
   template <typename prec, typename = std::enable_if_t<std::is_same_v<prec, std::remove_const_t<prec>>>>
   auto matrix(ndarray::ndarray<prec, 2>&& array) {
     return MMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);

--- a/src/green/impurity/ed_impurity_solver.h
+++ b/src/green/impurity/ed_impurity_solver.h
@@ -9,175 +9,21 @@ namespace green::impurity {
   class ed_impurity_solver {
   public:
     ed_impurity_solver(const std::string& input_file, const std::string& bath_file, const std::string& impurity_solver_exec,
-                       const std::string& impurity_solver_params, const std::string& root) :
-        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
-        _root(root) {
-      size_t        nimp;
-      h5pp::archive ar(input_file, "r");
-      ar["nimp"] >> nimp;
-      ar.close();
-      if(!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
-      std::ifstream ff(bath_file);
-      for (size_t imp = 0; imp < nimp; ++imp) {
-        std::vector<double> bath;
-        std::vector<int>    bath_structure;
-        size_t              nio, nbo;
-        ff >> nio >> nbo;
-        for (size_t io = 0; io < nio; ++io) {
-          int nb_io;
-          ff >> nb_io;
-          bath_structure.push_back(nb_io);
-        }
-        for (size_t bo = 0; bo < nbo * 2; ++bo) {
-          double b;
-          ff >> b;
-          bath.push_back(b);
-        }
-        // Store single-spin template; tiling to actual ns happens in solve()
-        dtensor<2> initial_bath(1, bath.size());
-        itensor<1> bath_struct(bath_structure.size());
-        std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
-        std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
-        _initial_bath.push_back(initial_bath);
-        _bath_structure.push_back(bath_struct);
-      }
-    }
+                       const std::string& impurity_solver_params, const std::string& root);
 
-    auto solve(size_t imp_n, const grids::transformer_t& _ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
-      ztensor<3> sigma_inf_new(delta_1.shape());
-      ztensor<4> sigma_new(delta_w.shape());
-      size_t     ns    = ovlp.shape()[0];
-      size_t     nbath = _initial_bath[imp_n].shape()[1];
-      dtensor<2> initial_bath_tiled(ns, nbath);
-      for (size_t is = 0; is < ns; ++is)
-        std::copy(_initial_bath[imp_n](0).begin(), _initial_bath[imp_n](0).end(), initial_bath_tiled(is).begin());
-      auto [delta_out, bath_arr] =
-          minimize(_ft.sd().repn_fermi().wsample() * 1.0i, delta_w, initial_bath_tiled, _bath_structure[imp_n], 1);
-      {
-        std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
-        for (auto b : bath_arr) {
-          ofile << b << " ";
-        }
-        ofile << std::endl;
-      }
-      size_t                  nio = ovlp.shape()[2];
-      size_t                  nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
-      dtensor<2>              Epsk(nb, ns);
-      std::vector<dtensor<2>> Vk;
-      for (size_t is = 0; is < ns; ++is) {
-        for (size_t io = 0, ik = 0, shift = 0; io < nio; ++io) {
-          size_t nk = _bath_structure[imp_n](io);
-          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
-            Epsk(ik, is) = bath_arr(is, shift + nk + iik);
-          }
-          shift += 2 * nk;
-        }
-      }
-      for (size_t io = 0; io < nio; ++io) {
-        dtensor<2> Vk_(Epsk.shape());
-        for (size_t io2 = 0, ik = 0, shift = 0; io2 < nio; io2++) {
-          size_t nk = _bath_structure[imp_n](io2);
-          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
-            for (size_t is = 0; is < ns; ++is) {
-              if (io == io2) Vk_(ik, is) = bath_arr(is, shift + iik);
-            }
-          }
-          shift += 2 * nk;
-        }
-        Vk.push_back(Vk_);
-      }
-      ztensor<4> g0_imp(delta_out.shape());
-      for (size_t iw = 0; iw < delta_out.shape()[0]; ++iw) {
-        for (size_t is = 0; is < ns; ++is) {
-          auto g_inv_w_imp =
-              matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(hcore_eff(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
-          auto xxx               = g_inv_w_imp.inverse().eval();
-          matrix(g0_imp(iw, is)) = xxx;
-        }
-      }
-      {
-        h5pp::archive data(_root + "/ed." + std::to_string(imp_n) + ".input.h5", "w");
-        data["freq"] << _ft.wsample_fermi();
-        data["G0_imp/data"] << g0_imp.view<double>();
-        data["G_imp/data"] << g_w;
-        data["Delta/data"] << delta_out;
-        data["Delta/data_in"] << delta_w;
-        data["Delta/static"] << delta_1;
-
-        itensor<2> sectors(1, 2);
-        sectors(0, 0) = 0;
-        sectors(0, 1) = 0;
-        auto hop_g    = data["sectors"];
-        hop_g["values"] << sectors;
-        auto bath   = data["Bath"];
-        // Post process H0->H0_imp
-        auto H0_imp = ndarray::transpose(hcore_eff + delta_1, "sij->ijs").astype<double>();
-
-        bath["Epsk/values"] << Epsk;
-        for (size_t io = 0; io < nio; ++io) {
-          bath["Vk_" + std::to_string(io) + "/values"] << Vk[io];
-          data["H0_" + std::to_string(io) + "/values"] << H0_imp(io);
-        }
-        dtensor<6> interaction_(2, 2, nio, nio, nio, nio);
-
-        // transform interaction into physics convention
-        auto interaction_phys = ndarray::transpose(interaction, "ijkl->ikjl");
-
-        interaction_(0, 0) << interaction_phys;
-        interaction_(0, 1) << interaction_phys;
-        interaction_(1, 0) << interaction_phys;
-        interaction_(1, 1) << interaction_phys;
-        data["interaction/values"] << interaction_;
-        data["mu"] << mu;
-        if (nio > 1) {
-          // Store the list of ordered orbital pairs for which G(io, jo) should be calculated
-          // NOTE: Diagonal part of G is handled differently
-          itensor<2> orbitals(nio * nio - nio, 2);
-          for (size_t io = 0, iii = 0; io < nio; ++io) {
-            for (size_t jo = 0; jo < nio; ++jo) {
-              if (io != jo) {
-                orbitals(iii, 0) = io;
-                orbitals(iii, 1) = jo;
-                ++iii;
-              }
-            }
-          }
-          data["GreensFunction_orbitals/values"] << orbitals;
-        }
-        data.close();
-      }
-      std::string run   = (_impurity_solver_exec + " " + _impurity_solver_params + " --NSITES=" + std::to_string(nio + nb) +
-                         " --NSPINS=" + std::to_string(2) + " --INPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) +
-                         ".input.h5" + " --OUTPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) + ".result.h5" +
-                         " --arpack.SECTOR=false --siam.NORBITALS=" +
-                         std::to_string(nio) + " --spinstorage.ORBITAL_NUMBER=" + std::to_string(nio) +
-                         " --lanc.BETA=" + std::to_string(_ft.sd().beta()));
-      int sysresult     = std::system(run.c_str());
-      if (std::filesystem::exists(_root + "/ed." + std::to_string(imp_n) + ".result.h5")) {
-        h5pp::archive ar(_root + "/ed." + std::to_string(imp_n) + ".result.h5", "r");
-        dtensor<3>    xxx;
-        ar["results/Sigma_inf_ij"] >> xxx;
-        sigma_inf_new.resize(xxx.shape());
-        sigma_inf_new << xxx;
-        ar["results/Sigma_ij"] >> sigma_new.view<double>();
-      } else {
-        std::cerr << "Impurity result file has not been found" << std::endl;
-      }
-      return std::make_tuple(sigma_inf_new, sigma_new);
-    }
+    std::tuple<ztensor<3>, ztensor<4>> solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp,
+                                             const ztensor<3>& hcore_eff, const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                             const dtensor<4>& interaction, const ztensor<4>& g_w) const;
 
   private:
     std::string             _input_file;
     std::string             _impurity_solver_exec;
     std::string             _impurity_solver_params;
     std::string             _root;
-    size_t                  _nimp;
     std::vector<dtensor<2>> _initial_bath;
     std::vector<itensor<1>> _bath_structure;
   };
 
-
-}
+}  // namespace green::impurity
 
 #endif  // GREEN_ED_IMPURITY_SOLVER_H

--- a/src/green/impurity/ed_impurity_solver.h
+++ b/src/green/impurity/ed_impurity_solver.h
@@ -1,9 +1,7 @@
 #ifndef GREEN_ED_IMPURITY_SOLVER_H
 #define GREEN_ED_IMPURITY_SOLVER_H
 
-#include <green/params/params.h>
 #include "common_defs.h"
-#include "bath_fitting.h"
 
 namespace green::impurity {
   class ed_impurity_solver {

--- a/src/green/impurity/ed_impurity_solver.h
+++ b/src/green/impurity/ed_impurity_solver.h
@@ -1,0 +1,183 @@
+#ifndef GREEN_ED_IMPURITY_SOLVER_H
+#define GREEN_ED_IMPURITY_SOLVER_H
+
+#include <green/params/params.h>
+#include "common_defs.h"
+#include "bath_fitting.h"
+
+namespace green::impurity {
+  class ed_impurity_solver {
+  public:
+    ed_impurity_solver(const std::string& input_file, const std::string& bath_file, const std::string& impurity_solver_exec,
+                       const std::string& impurity_solver_params, const std::string& root) :
+        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
+        _root(root) {
+      size_t        ns = 2;
+      size_t        nimp;
+      h5pp::archive ar(input_file, "r");
+      ar["nimp"] >> nimp;
+      ar.close();
+      if(!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
+      std::ifstream ff(bath_file);
+      for (size_t imp = 0; imp < nimp; ++imp) {
+        std::vector<double> bath;
+        std::vector<int>    bath_structure;
+        size_t              nio, nbo;
+        ff >> nio >> nbo;
+        for (size_t io = 0; io < nio; ++io) {
+          int nb_io;
+          ff >> nb_io;
+          bath_structure.push_back(nb_io);
+        }
+        for (size_t bo = 0; bo < nbo * 2; ++bo) {
+          double b;
+          ff >> b;
+          bath.push_back(b);
+        }
+        dtensor<2> initial_bath(ns, bath.size());
+        itensor<1> bath_struct(bath_structure.size());
+        // first spin
+        std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
+        // second spin
+        std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
+        std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
+        _initial_bath.push_back(initial_bath);
+        _bath_structure.push_back(bath_struct);
+      }
+    }
+
+    auto solve(size_t imp_n, const grids::transformer_t& _ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
+      ztensor<3> sigma_inf_new(delta_1.shape());
+      ztensor<4> sigma_new(delta_w.shape());
+      auto [delta_out, bath_arr] =
+          minimize(_ft.sd().repn_fermi().wsample() * 1.0i, delta_w, _initial_bath[imp_n], _bath_structure[imp_n], 1);
+      {
+        std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
+        for (auto b : bath_arr) {
+          ofile << b << " ";
+        }
+        ofile << std::endl;
+      }
+      size_t                  nio = ovlp.shape()[2];
+      size_t                  ns  = ovlp.shape()[0];
+      size_t                  nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
+      dtensor<2>              Epsk(nb, ns);
+      std::vector<dtensor<2>> Vk;
+      for (size_t is = 0; is < ns; ++is) {
+        for (size_t io = 0, ik = 0, shift = 0; io < nio; ++io) {
+          size_t nk = _bath_structure[imp_n](io);
+          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+            Epsk(ik, is) = bath_arr(is, shift + nk + iik);
+          }
+          shift += 2 * nk;
+        }
+      }
+      for (size_t io = 0; io < nio; ++io) {
+        dtensor<2> Vk_(Epsk.shape());
+        for (size_t io2 = 0, ik = 0, shift = 0; io2 < nio; io2++) {
+          size_t nk = _bath_structure[imp_n](io2);
+          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+            for (size_t is = 0; is < ns; ++is) {
+              if (io == io2) Vk_(ik, is) = bath_arr(is, shift + iik);
+            }
+          }
+          shift += 2 * nk;
+        }
+        Vk.push_back(Vk_);
+      }
+      ztensor<4> g0_imp(delta_out.shape());
+      for (size_t iw = 0; iw < delta_out.shape()[0]; ++iw) {
+        for (size_t is = 0; is < ns; ++is) {
+          auto g_inv_w_imp =
+              matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
+          auto g_inv_w_loc       = matrix(g_w(iw, is)).inverse().eval();
+          auto xxx               = g_inv_w_imp.inverse().eval();
+          matrix(g0_imp(iw, is)) = xxx;
+        }
+      }
+      {
+        h5pp::archive data(_root + "/ed." + std::to_string(imp_n) + ".input.h5", "w");
+        data["freq"] << _ft.wsample_fermi();
+        data["G0_imp/data"] << g0_imp.view<double>();
+        data["G_imp/data"] << g_w;
+        data["Delta/data"] << delta_out;
+        data["Delta/data_in"] << delta_w;
+        data["Delta/static"] << delta_1;
+
+        itensor<2> sectors(1, 2);
+        sectors(0, 0) = 0;
+        sectors(0, 1) = 0;
+        auto hop_g    = data["sectors"];
+        hop_g["values"] << sectors;
+        auto bath   = data["Bath"];
+        // Post process H0->H0_imp
+        auto H0_imp = ndarray::transpose(h_core + delta_1, "sij->ijs").astype<double>();
+
+        bath["Epsk/values"] << Epsk;
+        for (size_t io = 0; io < nio; ++io) {
+          bath["Vk_" + std::to_string(io) + "/values"] << Vk[io];
+          data["H0_" + std::to_string(io) + "/values"] << H0_imp(io);
+        }
+        dtensor<6> interaction_(2, 2, nio, nio, nio, nio);
+
+        // transform interaction into physics convention
+        auto interaction_phys = ndarray::transpose(interaction, "ijkl->ikjl");
+
+        interaction_(0, 0) << interaction_phys;
+        interaction_(0, 1) << interaction_phys;
+        interaction_(1, 0) << interaction_phys;
+        interaction_(1, 1) << interaction_phys;
+        data["interaction/values"] << interaction_;
+        data["mu"] << mu;
+        if (nio > 1) {
+          // Store the list of ordered orbital pairs for which G(io, jo) should be calculated
+          // NOTE: Diagonal part of G is handled differently
+          itensor<2> orbitals(nio * nio - nio, 2);
+          for (size_t io = 0, iii = 0; io < nio; ++io) {
+            for (size_t jo = 0; jo < nio; ++jo) {
+              if (io != jo) {
+                orbitals(iii, 0) = io;
+                orbitals(iii, 1) = jo;
+                ++iii;
+              }
+            }
+          }
+          data["GreensFunction_orbitals/values"] << orbitals;
+        }
+        data.close();
+      }
+      std::string run   = (_impurity_solver_exec + " " + _impurity_solver_params + " --NSITES=" + std::to_string(nio + nb) +
+                         " --NSPINS=" + std::to_string(2) + " --INPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) +
+                         ".input.h5" + " --OUTPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) + ".result.h5" +
+                         " --arpack.SECTOR=false --siam.NORBITALS=" +
+                         std::to_string(nio) + " --spinstorage.ORBITAL_NUMBER=" + std::to_string(nio) +
+                         " --lanc.BETA=" + std::to_string(_ft.sd().beta()));
+      int sysresult     = std::system(run.c_str());
+      if (std::filesystem::exists(_root + "/ed." + std::to_string(imp_n) + ".result.h5")) {
+        h5pp::archive ar(_root + "/ed." + std::to_string(imp_n) + ".result.h5", "r");
+        dtensor<3>    xxx;
+        ar["results/Sigma_inf_ij"] >> xxx;
+        sigma_inf_new.resize(xxx.shape());
+        sigma_inf_new << xxx;
+        ar["results/Sigma_ij"] >> sigma_new.view<double>();
+      } else {
+        std::cerr << "Impurity result file has not been found" << std::endl;
+      }
+      return std::make_tuple(sigma_inf_new, sigma_new);
+    }
+
+  private:
+    std::string             _input_file;
+    std::string             _impurity_solver_exec;
+    std::string             _impurity_solver_params;
+    std::string             _root;
+    size_t                  _nimp;
+    std::vector<dtensor<2>> _initial_bath;
+    std::vector<itensor<1>> _bath_structure;
+  };
+
+
+}
+
+#endif  // GREEN_ED_IMPURITY_SOLVER_H

--- a/src/green/impurity/ed_impurity_solver.h
+++ b/src/green/impurity/ed_impurity_solver.h
@@ -12,7 +12,6 @@ namespace green::impurity {
                        const std::string& impurity_solver_params, const std::string& root) :
         _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
         _root(root) {
-      size_t        ns = 2;
       size_t        nimp;
       h5pp::archive ar(input_file, "r");
       ar["nimp"] >> nimp;
@@ -34,24 +33,27 @@ namespace green::impurity {
           ff >> b;
           bath.push_back(b);
         }
-        dtensor<2> initial_bath(ns, bath.size());
+        // Store single-spin template; tiling to actual ns happens in solve()
+        dtensor<2> initial_bath(1, bath.size());
         itensor<1> bath_struct(bath_structure.size());
-        // first spin
         std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
-        // second spin
-        std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
         std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
         _initial_bath.push_back(initial_bath);
         _bath_structure.push_back(bath_struct);
       }
     }
 
-    auto solve(size_t imp_n, const grids::transformer_t& _ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+    auto solve(size_t imp_n, const grids::transformer_t& _ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
       ztensor<3> sigma_inf_new(delta_1.shape());
       ztensor<4> sigma_new(delta_w.shape());
+      size_t     ns    = ovlp.shape()[0];
+      size_t     nbath = _initial_bath[imp_n].shape()[1];
+      dtensor<2> initial_bath_tiled(ns, nbath);
+      for (size_t is = 0; is < ns; ++is)
+        std::copy(_initial_bath[imp_n](0).begin(), _initial_bath[imp_n](0).end(), initial_bath_tiled(is).begin());
       auto [delta_out, bath_arr] =
-          minimize(_ft.sd().repn_fermi().wsample() * 1.0i, delta_w, _initial_bath[imp_n], _bath_structure[imp_n], 1);
+          minimize(_ft.sd().repn_fermi().wsample() * 1.0i, delta_w, initial_bath_tiled, _bath_structure[imp_n], 1);
       {
         std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
         for (auto b : bath_arr) {
@@ -60,7 +62,6 @@ namespace green::impurity {
         ofile << std::endl;
       }
       size_t                  nio = ovlp.shape()[2];
-      size_t                  ns  = ovlp.shape()[0];
       size_t                  nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
       dtensor<2>              Epsk(nb, ns);
       std::vector<dtensor<2>> Vk;
@@ -90,8 +91,7 @@ namespace green::impurity {
       for (size_t iw = 0; iw < delta_out.shape()[0]; ++iw) {
         for (size_t is = 0; is < ns; ++is) {
           auto g_inv_w_imp =
-              matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
-          auto g_inv_w_loc       = matrix(g_w(iw, is)).inverse().eval();
+              matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(hcore_eff(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
           auto xxx               = g_inv_w_imp.inverse().eval();
           matrix(g0_imp(iw, is)) = xxx;
         }
@@ -112,7 +112,7 @@ namespace green::impurity {
         hop_g["values"] << sectors;
         auto bath   = data["Bath"];
         // Post process H0->H0_imp
-        auto H0_imp = ndarray::transpose(h_core + delta_1, "sij->ijs").astype<double>();
+        auto H0_imp = ndarray::transpose(hcore_eff + delta_1, "sij->ijs").astype<double>();
 
         bath["Epsk/values"] << Epsk;
         for (size_t io = 0; io < nio; ++io) {

--- a/src/green/impurity/except.h
+++ b/src/green/impurity/except.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 University of Michigan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef GREEN_IMPURITY_EXCEPT_H
+#define GREEN_IMPURITY_EXCEPT_H
+
+#include <stdexcept>
+#include <string>
+
+namespace green::impurity {
+
+  class incorr_impurity_solver_type : public std::runtime_error {
+  public:
+    explicit incorr_impurity_solver_type(const std::string& what) : std::runtime_error(what) {}
+  };
+
+  class impurity_solver_exec_error : public std::runtime_error {
+  public:
+    explicit impurity_solver_exec_error(const std::string& what) : std::runtime_error(what) {}
+  };
+
+  class impurity_result_not_found : public std::runtime_error {
+  public:
+    explicit impurity_result_not_found(const std::string& what) : std::runtime_error(what) {}
+  };
+
+}  // namespace green::impurity
+
+#endif  // GREEN_IMPURITY_EXCEPT_H

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -21,7 +21,7 @@ namespace green::impurity {
 
     static std::string build_launcher_cmd(const std::string& cmd) {
       if (has_env("SLURM_JOB_ID")) return "srun --ntasks=1 --overlap " + cmd;
-      return "mpirun -np 1 " + cmd;
+      return cmd;
     }
 
     void fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w,

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -54,7 +54,7 @@ namespace green::impurity {
       }
     }
 
-    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
       ztensor<3> sigma_inf_new(delta_1.shape());
       ztensor<4> sigma_new(delta_w.shape());
@@ -63,17 +63,17 @@ namespace green::impurity {
       dtensor<2> Epsk;
       std::vector<dtensor<2>> Vk;
       fit_and_parse_bath(imp_n, ft, mu, delta_w, ovlp, Epsk, Vk);
-      write_bath_debug(imp_n, ft, mu, ovlp, h_core, delta_1, delta_w, g_w, Epsk, Vk);
+      write_bath_debug(imp_n, ft, mu, ovlp, hcore_eff, delta_1, delta_w, g_w, Epsk, Vk);
 
       // Step 2: Prepare hybrid system and write GW input (generic future extension)
-      prepare_gw_input(imp_n, ovlp, h_core, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
+      prepare_gw_input(imp_n, ovlp, hcore_eff, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
 
       size_t nio = ovlp.shape()[2];
       size_t nb = Epsk.shape()[0];
       size_t ns = Epsk.shape()[1];
       std::string run = (_impurity_solver_exec +
-                        " --itermax 1 --const_density=false --scf_type=GW" +
-                        " --mixing_weight=1.0 --restart=true" +
+                        " --itermax 10 --const_density=false --scf_type=GW --E_thr=1e-5" +
+                        " --mixing_weight=0.7 --restart=true" +
                         " --BETA=" + std::to_string(ft.sd().beta()) +
                         " --input_file=" + _root + "/gw." + std::to_string(imp_n) + ".input.h5" +
                         " --results_file=" + _root + "/gw." + std::to_string(imp_n) + ".sim.h5") +
@@ -142,12 +142,12 @@ namespace green::impurity {
     void fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
                 dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const;
 
-    void prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
+    void prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const ztensor<3>& delta_1,
                 const ztensor<4>& delta_w,
                           const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
                           const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const;
 
-    void write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+    void write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                 const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
                 const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const;
     int launchCleanChild(const std::string &cmd) const {

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -63,8 +63,6 @@ namespace green::impurity {
       dtensor<2> Epsk;
       std::vector<dtensor<2>> Vk;
       fit_and_parse_bath(imp_n, ft, mu, delta_w, ovlp, Epsk, Vk);
-      write_bath_debug(imp_n, ft, mu, ovlp, hcore_eff, delta_1, delta_w, g_w, Epsk, Vk);
-
       // Step 2: Prepare hybrid system and write GW input (generic future extension)
       prepare_gw_input(imp_n, ovlp, hcore_eff, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
 
@@ -147,9 +145,6 @@ namespace green::impurity {
                           const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
                           const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const;
 
-    void write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
-                const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const;
     int launchCleanChild(const std::string &cmd) const {
       // Must unset stale per-rank vars before calling launcher.
       unsetenv("PMI_FD");

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -1,9 +1,9 @@
 #ifndef GREEN_GW_IMPURITY_SOLVER_H
 #define GREEN_GW_IMPURITY_SOLVER_H
 
+#include <array>
 #include <cstdlib>
 #include "common_defs.h"
-#include "bath_fitting.h"
 
 namespace green::impurity {
 
@@ -32,20 +32,17 @@ namespace green::impurity {
                           const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const;
 
     int launchCleanChild(const std::string& cmd) const {
-      unsetenv("PMI_FD");
-      unsetenv("PMI_RANK");
-      unsetenv("PMI_SIZE");
-      unsetenv("PMI_PORT");
-      unsetenv("PMIX_RANK");
-      unsetenv("PMIX_SERVER_URI");
-      unsetenv("PMIX_SERVER_URI2");
-      unsetenv("OMPI_COMM_WORLD_RANK");
-      unsetenv("OMPI_COMM_WORLD_SIZE");
-      unsetenv("OMPI_COMM_WORLD_LOCAL_RANK");
-      unsetenv("OMPI_COMM_WORLD_LOCAL_SIZE");
-      unsetenv("OMPI_COMM_WORLD_NODE_RANK");
-      unsetenv("OMPI_UNIVERSE_SIZE");
-      return std::system(build_launcher_cmd(cmd).c_str());
+      static constexpr std::array<const char*, 13> mpi_vars = {
+          "PMI_FD", "PMI_RANK", "PMI_SIZE", "PMI_PORT",
+          "PMIX_RANK", "PMIX_SERVER_URI", "PMIX_SERVER_URI2",
+          "OMPI_COMM_WORLD_RANK", "OMPI_COMM_WORLD_SIZE",
+          "OMPI_COMM_WORLD_LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_SIZE",
+          "OMPI_COMM_WORLD_NODE_RANK", "OMPI_UNIVERSE_SIZE"};
+      std::string env_prefix = "env";
+      for (const char* var : mpi_vars) {
+        if (has_env(var)) env_prefix += std::string(" -u ") + var;
+      }
+      return std::system((env_prefix + " " + build_launcher_cmd(cmd)).c_str());
     }
 
     std::string             _input_file;

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -1,0 +1,183 @@
+#ifndef GREEN_GW_IMPURITY_SOLVER_H
+#define GREEN_GW_IMPURITY_SOLVER_H
+
+#include <cstdlib>
+#include <green/params/params.h>
+#include "common_defs.h"
+#include "bath_fitting.h"
+
+namespace green::impurity {
+
+
+  class gw_impurity_solver {
+    template <typename prec>
+    using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+    template <typename prec>
+    using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
+  public:
+    gw_impurity_solver(const std::string& input_file, const std::string& bath_file, const std::string& impurity_solver_exec,
+                       const std::string& impurity_solver_params, const std::string dc_data_prefix, const std::string& root) :
+        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
+        _dc_data_prefix(dc_data_prefix), _root(root) {
+      size_t        ns = 2; // TODO: This is hardcoded - let it be for now
+      size_t        nimp;
+      h5pp::archive ar(input_file, "r");
+      ar["nimp"] >> nimp;
+      ar.close();
+      if(!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
+      std::ifstream ff(bath_file);
+      for (size_t imp = 0; imp < nimp; ++imp) {
+        std::vector<double> bath;
+        std::vector<int>    bath_structure;
+        size_t              nio, nbo;
+        ff >> nio >> nbo;
+        for (size_t io = 0; io < nio; ++io) {
+          int nb_io;
+          ff >> nb_io;
+          bath_structure.push_back(nb_io);
+        }
+        for (size_t bo = 0; bo < nbo * 2; ++bo) {
+          double b;
+          ff >> b;
+          bath.push_back(b);
+        }
+        dtensor<2> initial_bath(ns, bath.size());
+        itensor<1> bath_struct(bath_structure.size());
+        // first spin
+        std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
+        // second spin
+        std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
+        std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
+        _initial_bath.push_back(initial_bath);
+        _bath_structure.push_back(bath_struct);
+      }
+    }
+
+    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
+      ztensor<3> sigma_inf_new(delta_1.shape());
+      ztensor<4> sigma_new(delta_w.shape());
+
+      // Step 1: Bath fitting and parsing
+      dtensor<2> Epsk;
+      std::vector<dtensor<2>> Vk;
+      fit_and_parse_bath(imp_n, ft, mu, delta_w, ovlp, Epsk, Vk);
+      write_bath_debug(imp_n, ft, mu, ovlp, h_core, delta_1, delta_w, g_w, Epsk, Vk);
+
+      // Step 2: Prepare hybrid system and write GW input (generic future extension)
+      prepare_gw_input(imp_n, ovlp, h_core, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
+
+      size_t nio = ovlp.shape()[2];
+      size_t nb = Epsk.shape()[0];
+      size_t ns = Epsk.shape()[1];
+      std::string run = (_impurity_solver_exec +
+                        " --itermax 1 --const_density=false --scf_type=GW" +
+                        " --mixing_weight=1.0 --restart=true" +
+                        " --BETA=" + std::to_string(ft.sd().beta()) +
+                        " --input_file=" + _root + "/gw." + std::to_string(imp_n) + ".input.h5" +
+                        " --results_file=" + _root + "/gw." + std::to_string(imp_n) + ".sim.h5") +
+                        " --dfintegral_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
+                        " --dfintegral_hf_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
+                        " " + _impurity_solver_params;
+      std::cout << "\n\n\nWill run the following command!" << std::endl;
+      std::cout << run << std::endl;
+      std::cout << "\n\n\n----" << std::endl;
+      // int sysresult = std::system(run.c_str());
+      int sysresult = launchCleanChild(run);
+      if (sysresult != 0) {
+        throw std::runtime_error("Impurity GW child process failed with code " + std::to_string(sysresult));
+      }
+      if (std::filesystem::exists(_root + "/gw." + std::to_string(imp_n) + ".sim.h5")) {
+        h5pp::archive ar(_root + "/gw." + std::to_string(imp_n) + ".sim.h5", "r");
+        size_t it_num;
+        ar["iter"] >> it_num;
+          // Sigma1 is written as complex by sc_loop — read as ztensor, not dtensor.
+          ztensor<4> sigma_inf_imp_plus_bath;
+          ar["iter" + std::to_string(it_num) + "/Sigma1"] >> sigma_inf_imp_plus_bath;
+          for (size_t is = 0; is < ns; ++is) {
+            for (size_t i = 0; i < nio; ++i) {
+              for (size_t j = 0; j < nio; ++j) {
+                sigma_inf_new(is, i, j) = sigma_inf_imp_plus_bath(is, 0, i, j);
+              }
+            }
+          }
+          // Selfenergy/data is stored in tau domain (nt points) by green's sc_loop.
+          // Extract the impurity orbital block and transform tau -> omega before returning.
+          ztensor<5> sigma_tau_imp_plus_bath;
+          ar["iter" + std::to_string(it_num) + "/Selfenergy/data"] >> sigma_tau_imp_plus_bath;
+          size_t nt_read = sigma_tau_imp_plus_bath.shape()[0];
+          ztensor<4> sigma_tau_imp(nt_read, ns, nio, nio);
+          for (size_t it = 0; it < nt_read; ++it) {
+            for (size_t is = 0; is < ns; ++is) {
+              for (size_t i = 0; i < nio; ++i) {
+                for (size_t j = 0; j < nio; ++j) {
+                  sigma_tau_imp(it, is, i, j) = sigma_tau_imp_plus_bath(it, is, 0, i, j);
+                }
+              }
+            }
+          }
+          ft.tau_to_omega(sigma_tau_imp, sigma_new);
+      } else {
+        std::cerr << "Impurity result file has not been found" << std::endl;
+      }
+      return std::make_tuple(sigma_inf_new, sigma_new);
+    }
+
+  private:
+    static bool has_env(const char* var) {
+      return std::getenv(var) != nullptr;
+    }
+
+    static std::string build_launcher_cmd(const std::string& cmd) {
+      // SLURM takes priority: use srun to create a proper new step.
+      if (has_env("SLURM_JOB_ID")) {
+        return "srun --ntasks=1 --overlap " + cmd;
+      }
+
+      // Fallback: use single-rank mpirun.
+      return "mpirun -np 1 " + cmd;
+    }
+
+    void fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
+                dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const;
+
+    void prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
+                const ztensor<4>& delta_w,
+                          const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
+                          const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const;
+
+    void write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
+                const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const;
+    int launchCleanChild(const std::string &cmd) const {
+      // Must unset stale per-rank vars before calling launcher.
+      unsetenv("PMI_FD");
+      unsetenv("PMI_RANK");
+      unsetenv("PMI_SIZE");
+      unsetenv("PMI_PORT");
+      unsetenv("PMIX_RANK");
+      unsetenv("PMIX_SERVER_URI");
+      unsetenv("PMIX_SERVER_URI2");
+      unsetenv("OMPI_COMM_WORLD_RANK");
+      unsetenv("OMPI_COMM_WORLD_SIZE");
+      unsetenv("OMPI_COMM_WORLD_LOCAL_RANK");
+      unsetenv("OMPI_COMM_WORLD_LOCAL_SIZE");
+      unsetenv("OMPI_COMM_WORLD_NODE_RANK");
+      unsetenv("OMPI_UNIVERSE_SIZE");
+
+      std::string launch_cmd = build_launcher_cmd(cmd);
+      return std::system(launch_cmd.c_str());
+    }
+
+    std::string             _input_file;
+    std::string             _impurity_solver_exec;
+    std::string             _impurity_solver_params;
+    std::string             _dc_data_prefix;
+    std::string             _root;
+    size_t                  _nimp;
+    std::vector<dtensor<2>> _initial_bath;
+    std::vector<itensor<1>> _bath_structure;
+  };
+}  // namespace green::impurity
+#endif  // GREEN_GW_IMPURITY_SOLVER_H

--- a/src/green/impurity/gw_impurity_solver.h
+++ b/src/green/impurity/gw_impurity_solver.h
@@ -2,151 +2,36 @@
 #define GREEN_GW_IMPURITY_SOLVER_H
 
 #include <cstdlib>
-#include <green/params/params.h>
 #include "common_defs.h"
 #include "bath_fitting.h"
 
 namespace green::impurity {
 
-
   class gw_impurity_solver {
-    template <typename prec>
-    using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-    template <typename prec>
-    using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-
   public:
     gw_impurity_solver(const std::string& input_file, const std::string& bath_file, const std::string& impurity_solver_exec,
-                       const std::string& impurity_solver_params, const std::string dc_data_prefix, const std::string& root) :
-        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
-        _dc_data_prefix(dc_data_prefix), _root(root) {
-      size_t        ns = 2; // TODO: This is hardcoded - let it be for now
-      size_t        nimp;
-      h5pp::archive ar(input_file, "r");
-      ar["nimp"] >> nimp;
-      ar.close();
-      if(!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
-      std::ifstream ff(bath_file);
-      for (size_t imp = 0; imp < nimp; ++imp) {
-        std::vector<double> bath;
-        std::vector<int>    bath_structure;
-        size_t              nio, nbo;
-        ff >> nio >> nbo;
-        for (size_t io = 0; io < nio; ++io) {
-          int nb_io;
-          ff >> nb_io;
-          bath_structure.push_back(nb_io);
-        }
-        for (size_t bo = 0; bo < nbo * 2; ++bo) {
-          double b;
-          ff >> b;
-          bath.push_back(b);
-        }
-        dtensor<2> initial_bath(ns, bath.size());
-        itensor<1> bath_struct(bath_structure.size());
-        // first spin
-        std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
-        // second spin
-        std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
-        std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
-        _initial_bath.push_back(initial_bath);
-        _bath_structure.push_back(bath_struct);
-      }
-    }
+                       const std::string& impurity_solver_params, const std::string dc_data_prefix, const std::string& root);
 
-    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
-      ztensor<3> sigma_inf_new(delta_1.shape());
-      ztensor<4> sigma_new(delta_w.shape());
-
-      // Step 1: Bath fitting and parsing
-      dtensor<2> Epsk;
-      std::vector<dtensor<2>> Vk;
-      fit_and_parse_bath(imp_n, ft, mu, delta_w, ovlp, Epsk, Vk);
-      // Step 2: Prepare hybrid system and write GW input (generic future extension)
-      prepare_gw_input(imp_n, ovlp, hcore_eff, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
-
-      size_t nio = ovlp.shape()[2];
-      size_t nb = Epsk.shape()[0];
-      size_t ns = Epsk.shape()[1];
-      std::string run = (_impurity_solver_exec +
-                        " --itermax 10 --const_density=false --scf_type=GW --E_thr=1e-5" +
-                        " --mixing_weight=0.7 --restart=true" +
-                        " --BETA=" + std::to_string(ft.sd().beta()) +
-                        " --input_file=" + _root + "/gw." + std::to_string(imp_n) + ".input.h5" +
-                        " --results_file=" + _root + "/gw." + std::to_string(imp_n) + ".sim.h5") +
-                        " --dfintegral_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
-                        " --dfintegral_hf_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
-                        " " + _impurity_solver_params;
-      std::cout << "\n\n\nWill run the following command!" << std::endl;
-      std::cout << run << std::endl;
-      std::cout << "\n\n\n----" << std::endl;
-      // int sysresult = std::system(run.c_str());
-      int sysresult = launchCleanChild(run);
-      if (sysresult != 0) {
-        throw std::runtime_error("Impurity GW child process failed with code " + std::to_string(sysresult));
-      }
-      if (std::filesystem::exists(_root + "/gw." + std::to_string(imp_n) + ".sim.h5")) {
-        h5pp::archive ar(_root + "/gw." + std::to_string(imp_n) + ".sim.h5", "r");
-        size_t it_num;
-        ar["iter"] >> it_num;
-          // Sigma1 is written as complex by sc_loop — read as ztensor, not dtensor.
-          ztensor<4> sigma_inf_imp_plus_bath;
-          ar["iter" + std::to_string(it_num) + "/Sigma1"] >> sigma_inf_imp_plus_bath;
-          for (size_t is = 0; is < ns; ++is) {
-            for (size_t i = 0; i < nio; ++i) {
-              for (size_t j = 0; j < nio; ++j) {
-                sigma_inf_new(is, i, j) = sigma_inf_imp_plus_bath(is, 0, i, j);
-              }
-            }
-          }
-          // Selfenergy/data is stored in tau domain (nt points) by green's sc_loop.
-          // Extract the impurity orbital block and transform tau -> omega before returning.
-          ztensor<5> sigma_tau_imp_plus_bath;
-          ar["iter" + std::to_string(it_num) + "/Selfenergy/data"] >> sigma_tau_imp_plus_bath;
-          size_t nt_read = sigma_tau_imp_plus_bath.shape()[0];
-          ztensor<4> sigma_tau_imp(nt_read, ns, nio, nio);
-          for (size_t it = 0; it < nt_read; ++it) {
-            for (size_t is = 0; is < ns; ++is) {
-              for (size_t i = 0; i < nio; ++i) {
-                for (size_t j = 0; j < nio; ++j) {
-                  sigma_tau_imp(it, is, i, j) = sigma_tau_imp_plus_bath(it, is, 0, i, j);
-                }
-              }
-            }
-          }
-          ft.tau_to_omega(sigma_tau_imp, sigma_new);
-      } else {
-        std::cerr << "Impurity result file has not been found" << std::endl;
-      }
-      return std::make_tuple(sigma_inf_new, sigma_new);
-    }
+    std::tuple<ztensor<3>, ztensor<4>> solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp,
+                                             const ztensor<3>& hcore_eff, const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                             const dtensor<4>& interaction, const ztensor<4>& g_w) const;
 
   private:
-    static bool has_env(const char* var) {
-      return std::getenv(var) != nullptr;
-    }
+    static bool has_env(const char* var) { return std::getenv(var) != nullptr; }
 
     static std::string build_launcher_cmd(const std::string& cmd) {
-      // SLURM takes priority: use srun to create a proper new step.
-      if (has_env("SLURM_JOB_ID")) {
-        return "srun --ntasks=1 --overlap " + cmd;
-      }
-
-      // Fallback: use single-rank mpirun.
+      if (has_env("SLURM_JOB_ID")) return "srun --ntasks=1 --overlap " + cmd;
       return "mpirun -np 1 " + cmd;
     }
 
-    void fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
-                dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const;
+    void fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w,
+                            const ztensor<3>& ovlp, dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const;
 
     void prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const ztensor<3>& delta_1,
-                const ztensor<4>& delta_w,
-                          const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
+                          const ztensor<4>& delta_w, const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
                           const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const;
 
-    int launchCleanChild(const std::string &cmd) const {
-      // Must unset stale per-rank vars before calling launcher.
+    int launchCleanChild(const std::string& cmd) const {
       unsetenv("PMI_FD");
       unsetenv("PMI_RANK");
       unsetenv("PMI_SIZE");
@@ -160,9 +45,7 @@ namespace green::impurity {
       unsetenv("OMPI_COMM_WORLD_LOCAL_SIZE");
       unsetenv("OMPI_COMM_WORLD_NODE_RANK");
       unsetenv("OMPI_UNIVERSE_SIZE");
-
-      std::string launch_cmd = build_launcher_cmd(cmd);
-      return std::system(launch_cmd.c_str());
+      return std::system(build_launcher_cmd(cmd).c_str());
     }
 
     std::string             _input_file;
@@ -170,9 +53,9 @@ namespace green::impurity {
     std::string             _impurity_solver_params;
     std::string             _dc_data_prefix;
     std::string             _root;
-    size_t                  _nimp;
     std::vector<dtensor<2>> _initial_bath;
     std::vector<itensor<1>> _bath_structure;
   };
+
 }  // namespace green::impurity
 #endif  // GREEN_GW_IMPURITY_SOLVER_H

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -22,223 +22,15 @@
 #ifndef GREEN_IMPURITY_SOLVER_H
 #define GREEN_IMPURITY_SOLVER_H
 
-#include <green/grids/transformer_t.h>
-#include <green/ndarray/ndarray_math.h>
-#include <green/params/params.h>
-#include <green/symmetry/symmetry.h>
-#include <green/utils/mpi_shared.h>
-
-#include <tuple>
-
-#include "bath_fitting.h"
+#include "common_defs.h"
+#include "ed_impurity_solver.h"
 #include "inchworm_impurity_solver.h"
+#include "gw_impurity_solver.h"
 
 namespace green::impurity {
 
-  template <size_t N>
-  using ztensor = ndarray::ndarray<std::complex<double>, N>;
-  template <size_t N>
-  using dtensor = ndarray::ndarray<double, N>;
-  template <size_t N>
-  using itensor    = ndarray::ndarray<int, N>;
-  using bz_utils_t = symmetry::brillouin_zone_utils<symmetry::inv_symm_op>;
-
-  template <typename prec>
-  using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-  template <typename prec>
-  using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-  template <typename prec, typename = std::enable_if_t<std::is_same_v<prec, std::remove_const_t<prec>>>>
-  auto matrix(ndarray::ndarray<prec, 2>&& array) {
-    return MMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);
-  }
-
-  template <typename prec>
-  auto matrix(const ndarray::ndarray<const prec, 2>& array) {
-    return CMMatrixX<prec>(const_cast<prec*>(array.data()), array.shape()[0], array.shape()[1]);
-  }
-
-  template <typename prec>
-  auto matrix(ndarray::ndarray<const prec, 2>&& array) {
-    return CMMatrixX<prec>(const_cast<prec*>(array.data()), array.shape()[0], array.shape()[1]);
-  }
-
-  template <typename prec>
-  auto matrix(const ndarray::ndarray<prec, 2>& array) {
-    return CMMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);
-  }
-
   using green_dc_func = std::function<void(
         std::string, int imp_n, utils::shared_object<ztensor<5>>&, ztensor<4>&, utils::shared_object<ztensor<5>>&)>;
-
-  class ed_impurity_solver {
-  public:
-    ed_impurity_solver(const std::string& input_file, const std::string& bath_file, const std::string& impurity_solver_exec,
-                       const std::string& impurity_solver_params, const std::string& root) :
-        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
-        _root(root) {
-      size_t        ns = 2;
-      size_t        nimp;
-      h5pp::archive ar(input_file, "r");
-      ar["nimp"] >> nimp;
-      ar.close();
-      if(!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
-      std::ifstream ff(bath_file);
-      for (size_t imp = 0; imp < nimp; ++imp) {
-        std::vector<double> bath;
-        std::vector<int>    bath_structure;
-        size_t              nio, nbo;
-        ff >> nio >> nbo;
-        for (size_t io = 0; io < nio; ++io) {
-          int nb_io;
-          ff >> nb_io;
-          bath_structure.push_back(nb_io);
-        }
-        for (size_t bo = 0; bo < nbo * 2; ++bo) {
-          double b;
-          ff >> b;
-          bath.push_back(b);
-        }
-        dtensor<2> initial_bath(ns, bath.size());
-        itensor<1> bath_struct(bath_structure.size());
-        // first spin
-        std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
-        // second spin
-        std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
-        std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
-        _initial_bath.push_back(initial_bath);
-        _bath_structure.push_back(bath_struct);
-      }
-    }
-
-    auto solve(size_t imp_n, const grids::transformer_t& _ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
-      ztensor<3> sigma_inf_new(delta_1.shape());
-      ztensor<4> sigma_new(delta_w.shape());
-      auto [delta_out, bath_arr] =
-          minimize(_ft.sd().repn_fermi().wsample() * 1.0i, delta_w, _initial_bath[imp_n], _bath_structure[imp_n], 1);
-      {
-        std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
-        for (auto b : bath_arr) {
-          ofile << b << " ";
-        }
-        ofile << std::endl;
-      }
-      size_t                  nio = ovlp.shape()[2];
-      size_t                  ns  = ovlp.shape()[0];
-      size_t                  nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
-      dtensor<2>              Epsk(nb, ns);
-      std::vector<dtensor<2>> Vk;
-      for (size_t is = 0; is < ns; ++is) {
-        for (size_t io = 0, ik = 0, shift = 0; io < nio; ++io) {
-          size_t nk = _bath_structure[imp_n](io);
-          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
-            Epsk(ik, is) = bath_arr(is, shift + nk + iik);
-          }
-          shift += 2 * nk;
-        }
-      }
-      for (size_t io = 0; io < nio; ++io) {
-        dtensor<2> Vk_(Epsk.shape());
-        for (size_t io2 = 0, ik = 0, shift = 0; io2 < nio; io2++) {
-          size_t nk = _bath_structure[imp_n](io2);
-          for (size_t iik = 0; iik < nk; ++iik, ++ik) {
-            for (size_t is = 0; is < ns; ++is) {
-              if (io == io2) Vk_(ik, is) = bath_arr(is, shift + iik);
-            }
-          }
-          shift += 2 * nk;
-        }
-        Vk.push_back(Vk_);
-      }
-      ztensor<4> g0_imp(delta_out.shape());
-      for (size_t iw = 0; iw < delta_out.shape()[0]; ++iw) {
-        for (size_t is = 0; is < ns; ++is) {
-          auto g_inv_w_imp =
-              matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) - matrix(delta_1(is)) - matrix(delta_out(iw, is));
-          auto g_inv_w_loc       = matrix(g_w(iw, is)).inverse().eval();
-          auto xxx               = g_inv_w_imp.inverse().eval();
-          matrix(g0_imp(iw, is)) = xxx;
-        }
-      }
-      {
-        h5pp::archive data(_root + "/ed." + std::to_string(imp_n) + ".input.h5", "w");
-        data["freq"] << _ft.wsample_fermi();
-        data["G0_imp/data"] << g0_imp.view<double>();
-        data["G_imp/data"] << g_w;
-        data["Delta/data"] << delta_out;
-        data["Delta/data_in"] << delta_w;
-        data["Delta/static"] << delta_1;
-
-        itensor<2> sectors(1, 2);
-        sectors(0, 0) = 0;
-        sectors(0, 1) = 0;
-        auto hop_g    = data["sectors"];
-        hop_g["values"] << sectors;
-        auto bath   = data["Bath"];
-        // Post process H0->H0_imp
-        auto H0_imp = ndarray::transpose(h_core + delta_1, "sij->ijs").astype<double>();
-
-        bath["Epsk/values"] << Epsk;
-        for (size_t io = 0; io < nio; ++io) {
-          bath["Vk_" + std::to_string(io) + "/values"] << Vk[io];
-          data["H0_" + std::to_string(io) + "/values"] << H0_imp(io);
-        }
-        dtensor<6> interaction_(2, 2, nio, nio, nio, nio);
-
-        // transform interaction into physics convention
-        auto interaction_phys = ndarray::transpose(interaction, "ijkl->ikjl");
-
-        interaction_(0, 0) << interaction_phys;
-        interaction_(0, 1) << interaction_phys;
-        interaction_(1, 0) << interaction_phys;
-        interaction_(1, 1) << interaction_phys;
-        data["interaction/values"] << interaction_;
-        data["mu"] << mu;
-        if (nio > 1) {
-          itensor<2> orbitals(nio * nio - nio, 2);
-          for (size_t io = 0, iii = 0; io < nio; ++io) {
-            for (size_t jo = 0; jo < nio; ++jo) {
-              if (io != jo) {
-                orbitals(iii, 0) = io;
-                orbitals(iii, 1) = jo;
-                ++iii;
-              }
-            }
-          }
-          data["GreensFunction_orbitals/values"] << orbitals;
-        }
-        data.close();
-      }
-      std::string run       = (_impurity_solver_exec + " " + _impurity_solver_params + " --NSITES=" + std::to_string(nio + nb) +
-                         " --NSPINS=" + std::to_string(2) + " --INPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) +
-                         ".input.h5" + " --OUTPUT_FILE=" + _root + "/ed." + std::to_string(imp_n) + ".result.h5" +
-                         " --arpack.SECTOR=false"
-                               " --siam.NORBITALS=" +
-                         std::to_string(nio) + " --spinstorage.ORBITAL_NUMBER=" + std::to_string(nio) +
-                         " --lanc.BETA=" + std::to_string(_ft.sd().beta()));
-      int         sysresult = std::system(run.c_str());
-      if (std::filesystem::exists(_root + "/ed." + std::to_string(imp_n) + ".result.h5")) {
-        h5pp::archive ar(_root + "/ed." + std::to_string(imp_n) + ".result.h5", "r");
-        dtensor<3>    xxx;
-        ar["results/Sigma_inf_ij"] >> xxx;
-        sigma_inf_new.resize(xxx.shape());
-        sigma_inf_new << xxx;
-        ar["results/Sigma_ij"] >> sigma_new.view<double>();
-      } else {
-        std::cerr << "Impurity result file has not been found" << std::endl;
-      }
-      return std::make_tuple(sigma_inf_new, sigma_new);
-    }
-
-  private:
-    std::string             _input_file;
-    std::string             _impurity_solver_exec;
-    std::string             _impurity_solver_params;
-    std::string             _root;
-    size_t                  _nimp;
-    std::vector<dtensor<2>> _initial_bath;
-    std::vector<itensor<1>> _bath_structure;
-  };
 
   class impurity_solver {
     using func    = std::function<std::tuple<ztensor<3>, ztensor<4>>(
@@ -273,6 +65,15 @@ namespace green::impurity {
                                            const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
                                            const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
           return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
+              ->solve(imp_n, _ft, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
+        };
+      } else if (p["impurity_solver"].as<std::string>() == "GW") {
+        std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
+                                                             p["impurity_solver_params"], _dc_data_prefix, p["seet_root_dir"]));
+        _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
+                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+          return static_cast<gw_impurity_solver*>(gw_solver.get())
               ->solve(imp_n, _ft, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
         };
       }
@@ -339,7 +140,6 @@ namespace green::impurity {
                            matrix(sigma_w(iw, is));
         auto g_inv_w_loc      = matrix(g_w(iw, is)).inverse().eval();
         matrix(delta(iw, is)) = g_inv_w_imp - g_inv_w_loc;
-        auto xxx              = g_inv_w_imp.inverse().eval();
       }
     }
     if (_spin_symm) {
@@ -412,10 +212,23 @@ namespace green::impurity {
       g_dc.object() << g_as.reshape(shape_in);
       g_dc.fence();
 
+      // DEBUG save
+      h5pp::archive debug_data("debug." + std::to_string(imp) + ".output.h5", "w");
+      debug_data["dc/G_tau_in"] << g_dc.object();
+
       ztensor<4> sigma_inf_dc(shape_in_inf);
       _dc_solver(_dc_data_prefix, imp, g_dc, sigma_inf_dc, sigma_dc);
-      sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
+
+      // Transform impurity solver results from Omega to Tau
       _ft.omega_to_tau(sigma_w_new, sigma_as);
+      debug_data["dc/Sigma1_out"] << sigma_inf_dc;
+      debug_data["dc/Sigma_tau_out"] << sigma_dc.object();
+      debug_data["impurity/Sigma1_raw"] << sigma_inf_new;
+      debug_data["impurity/Sigma_tau_raw"] << sigma_as;
+      debug_data.close();
+
+      // Update impurity results by subtracting DC sigma
+      sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
       sigma_as -= sigma_dc.object().reshape(shape_out);
       for (size_t is = 0; is < ns; ++is) {
         matrix(sigma_inf_loc_new(is)) += matrix(uu).transpose() * matrix(sigma_inf_new(is)) * matrix(uu);

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -118,10 +118,6 @@ namespace green::impurity {
   inline auto impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                                          const dtensor<4>& interaction, const ztensor<3>& sigma_inf,
                                          const ztensor<4>& sigma_w, const ztensor<4>& g_w) const {
-    if (!std::filesystem::exists(_root)) {
-      std::filesystem::create_directory(_root);
-    }
-
     auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
     return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
   }
@@ -175,6 +171,9 @@ namespace green::impurity {
 
   inline auto impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
                                      const ztensor<4>& sigma, const ztensor<4>& g) const {
+    if (!std::filesystem::exists(_root)) {
+      std::filesystem::create_directory(_root);
+    }
     size_t     nt = _ft.sd().repn_fermi().nts();
     size_t     ns = ovlp.shape()[0];
     ztensor<3> sigma_inf_loc_new(sigma_inf.shape());

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -33,7 +33,7 @@ namespace green::impurity {
         std::string, int imp_n, utils::shared_object<ztensor<5>>&, ztensor<4>&, utils::shared_object<ztensor<5>>&)>;
 
   class impurity_solver {
-    using func    = std::function<std::tuple<ztensor<3>, ztensor<4>>(
+    using func = std::function<std::tuple<ztensor<3>, ztensor<4>>(
         size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
         const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w)>;
 
@@ -49,11 +49,11 @@ namespace green::impurity {
       if(p["impurity_solver"].as<std::string>() == "ED") {
         std::shared_ptr<void> ed_solver(new ed_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
                                                              p["impurity_solver_params"], p["seet_root_dir"]));
-        _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+        _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                                            const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
                                            const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
           return static_cast<ed_impurity_solver*>(ed_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
         };
       } else if (p["impurity_solver"].as<std::string>() == "INCHWORM") {
         if (p["itermax"].as<int>() > 1 && p["mixing_type"].as<std::string>() != "SIGMA_MIXING") {
@@ -61,20 +61,20 @@ namespace green::impurity {
         }
         std::shared_ptr<void> inchworm_solver(new inchworm_impurity_solver(p["seet_input"], p["impurity_solver_exec"],
                                                              p["impurity_solver_params"], p["seet_root_dir"]));
-        _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+        _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                                            const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
                                            const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
           return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
         };
       } else if (p["impurity_solver"].as<std::string>() == "GW") {
         std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
                                                              p["impurity_solver_params"], _dc_data_prefix, p["seet_root_dir"]));
-        _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+        _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                                            const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
                                            const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
           return static_cast<gw_impurity_solver*>(gw_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
         };
       }
     }
@@ -93,7 +93,7 @@ namespace green::impurity {
     green_dc_func               _dc_solver;
     std::string                 _dc_data_prefix;
 
-    auto solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const dtensor<4>& interaction,
+    auto solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const dtensor<4>& interaction,
                    const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w, const ztensor<4>& g_w) const;
 
     auto extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
@@ -115,15 +115,15 @@ namespace green::impurity {
                        const ztensor<2>& UU) const -> std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>>;
   };
 
-  inline auto impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                         const dtensor<4>& interaction, const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
-                                         const ztensor<4>& g_w) const {
+  inline auto impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                         const dtensor<4>& interaction, const ztensor<3>& sigma_inf,
+                                         const ztensor<4>& sigma_w, const ztensor<4>& g_w) const {
     if (!std::filesystem::exists(_root)) {
       std::filesystem::create_directory(_root);
     }
 
-    auto [delta_1, delta_w] = extract_delta(mu, ovlp, h_core, sigma_inf, sigma_w, g_w);
-    return _impurity_call(imp_n, mu, ovlp, h_core, delta_1, delta_w, interaction, g_w);
+    auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
+    return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
   }
 
   inline auto impurity_solver::extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
@@ -197,7 +197,6 @@ namespace green::impurity {
       ztensor<4> sigma_as_w(_ft.sd().repn_fermi().nw(), sigma_as.shape()[1], sigma_as.shape()[2], sigma_as.shape()[3]);
       _ft.tau_to_omega(g_as, g_as_w);
       _ft.tau_to_omega(sigma_as, sigma_as_w);
-      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, h_core_as, interaction, sigma_inf_as, sigma_as_w, g_as_w);
       std::array<size_t, 5> shape_in{nt, ns, 1, naso, naso};
       std::array<size_t, 4> shape_in_inf{ns, 1, naso, naso};
       std::array<size_t, 4> shape_out{nt, ns, naso, naso};
@@ -212,15 +211,29 @@ namespace green::impurity {
       g_dc.object() << g_as.reshape(shape_in);
       g_dc.fence();
 
-      // DEBUG save
-      h5pp::archive debug_data("debug." + std::to_string(imp) + ".output.h5", "w");
-      debug_data["dc/G_tau_in"] << g_dc.object();
-
+      // Compute DC self-energy before calling the impurity solver so that
+      // sigma_inf_dc is available for constructing H0_imp = h_core + sigma_inf - sigma_inf_dc
       ztensor<4> sigma_inf_dc(shape_in_inf);
       _dc_solver(_dc_data_prefix, imp, g_dc, sigma_inf_dc, sigma_dc);
 
+      // Effective impurity Hamiltonian: H0_imp = h_core + Re(sigma_inf - sigma_inf_dc) (+ delta_1 static hybridization).
+      // The imaginary part is discarded because the ED Hamiltonian must be real; sigma_inf and sigma_inf_dc are
+      // Hermitian so their difference should be real in a proper basis.
+      ztensor<3> sigma_inf_dc_3d(shape_out_inf);
+      sigma_inf_dc_3d << sigma_inf_dc.reshape(shape_out_inf);
+      ztensor<3> hcore_eff_as(h_core_as.shape());
+      for (size_t is = 0; is < h_core_as.shape()[0]; ++is) {
+        matrix(hcore_eff_as(is)) = matrix(h_core_as(is)) +
+            (matrix(sigma_inf_as(is)) - matrix(sigma_inf_dc_3d(is))).real();
+      }
+      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_as, sigma_as_w, g_as_w);
+
       // Transform impurity solver results from Omega to Tau
       _ft.omega_to_tau(sigma_w_new, sigma_as);
+
+      // DEBUG save
+      h5pp::archive debug_data("debug." + std::to_string(imp) + ".output.h5", "w");
+      debug_data["dc/G_tau_in"] << g_dc.object();
       debug_data["dc/Sigma1_out"] << sigma_inf_dc;
       debug_data["dc/Sigma_tau_out"] << sigma_dc.object();
       debug_data["impurity/Sigma1_raw"] << sigma_inf_new;

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -231,15 +231,6 @@ namespace green::impurity {
       // Transform impurity solver results from Omega to Tau
       _ft.omega_to_tau(sigma_w_new, sigma_as);
 
-      // DEBUG save
-      h5pp::archive debug_data("debug." + std::to_string(imp) + ".output.h5", "w");
-      debug_data["dc/G_tau_in"] << g_dc.object();
-      debug_data["dc/Sigma1_out"] << sigma_inf_dc;
-      debug_data["dc/Sigma_tau_out"] << sigma_dc.object();
-      debug_data["impurity/Sigma1_raw"] << sigma_inf_new;
-      debug_data["impurity/Sigma_tau_raw"] << sigma_as;
-      debug_data.close();
-
       // Update impurity results by subtracting DC sigma
       sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
       sigma_as -= sigma_dc.object().reshape(shape_out);

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -38,8 +38,21 @@ namespace green::impurity {
     impurity_solver(const green::params::params& p, const grids::transformer_t& ft, const bz_utils_t& bz_utils,
                     const green_dc_func& dc_func);
 
+    /**
+     * Solve all impurity problems and return the total impurity self-energy correction.
+     *
+     * @param mu         chemical potential
+     * @param ovlp       overlap matrix (local, orthogonal basis)
+     * @param h_core     one-body Hamiltonian (local)
+     * @param sigma_inf_weak  static self-energy from the weak-coupling solver (HF/GW)
+     * @param sigma_inf_full  full static self-energy including impurity corrections from previous iterations
+     * @param sigma      dynamic self-energy (tau, local)
+     * @param g          Green's function (tau, local)
+     * @return (sigma_inf_imp, sigma_tau_imp): impurity correction to static and dynamic self-energy,
+     *         with double-counting already subtracted, ready to be added to the weak-coupling result
+     */
     std::tuple<ztensor<3>, ztensor<4>> solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                             const ztensor<3>& sigma_inf, const ztensor<3>& sigma_inf_full,
+                                             const ztensor<3>& sigma_inf_weak, const ztensor<3>& sigma_inf_full,
                                              const ztensor<4>& sigma, const ztensor<4>& g) const;
 
   private:
@@ -53,24 +66,30 @@ namespace green::impurity {
     green_dc_func               _dc_solver;
     std::string                 _dc_data_prefix;
 
-    std::tuple<ztensor<3>, ztensor<4>> solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                                 const dtensor<4>& interaction, const ztensor<3>& sigma_inf,
-                                                 const ztensor<4>& sigma_w, const ztensor<4>& g_w) const;
-
-    std::tuple<ztensor<3>, ztensor<4>> extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                                     const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
-                                                     const ztensor<4>& g_w) const;
+    /**
+     * Extract the bath hybridization function Delta(iw) from the impurity and local Green's functions.
+     *
+     * Implements:  Delta(iw) = G_imp^{-1}(iw) - G_loc^{-1}(iw)
+     * where        G_imp^{-1}(iw) = (iw + mu)*S - fock_act_loc - Sigma_w
+     * and          fock_act_loc = h_core + sigma_inf_full  (Python's F_act_loc)
+     *
+     * Returns (delta_1, delta_w): static offset and frequency-dependent bath hybridization.
+     */
+    std::tuple<ztensor<3>, ztensor<4>> extract_delta(double mu, const ztensor<3>& ovlp,
+                                                     const ztensor<3>& fock_act_loc,
+                                                     const ztensor<4>& sigma_w, const ztensor<4>& g_w) const;
 
     /**
-     * Project impurity quantities to active space
-     * @param mu chemical potential
-     * @param ovlp overlap matrix
-     * @param h_core kinetic Hamiltonian
-     * @param sigma_inf impurity static self-energy
-     * @param sigma impurity dynamic self-energy
-     * @param g impurity Green's function
-     * @param UU transformation to active space
-     * @return tuple of projected (ovlp, h_core, sigma_inf, g, sigma)
+     * Project quantities from the orthogonal full space to the active space (AS).
+     *
+     * @param mu           chemical potential
+     * @param ovlp         overlap
+     * @param h_core       one-body Hamiltonian
+     * @param sigma_inf    weak static self-energy to be projected
+     * @param sigma        dynamic self-energy (tau)
+     * @param g            Green's function (tau)
+     * @param UU           active-space projection matrix (naso x nso)
+     * @return tuple (ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as)
      */
     std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>> project_to_as(
         double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf, const ztensor<4>& sigma,

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -39,8 +39,8 @@ namespace green::impurity {
                     const green_dc_func& dc_func);
 
     std::tuple<ztensor<3>, ztensor<4>> solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                             const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
-                                             const ztensor<4>& g) const;
+                                             const ztensor<3>& sigma_inf, const ztensor<3>& sigma_inf_full,
+                                             const ztensor<4>& sigma, const ztensor<4>& g) const;
 
   private:
     std::string                 _input_file;

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 University of Michigan
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the “Software”), to deal in the Software
+ * software and associated documentation files (the "Software"), to deal in the Software
  * without restriction, including without limitation the rights to use, copy, modify,
  * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to the following
@@ -11,7 +11,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
  * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
@@ -23,9 +23,6 @@
 #define GREEN_IMPURITY_SOLVER_H
 
 #include "common_defs.h"
-#include "ed_impurity_solver.h"
-#include "inchworm_impurity_solver.h"
-#include "gw_impurity_solver.h"
 
 namespace green::impurity {
 
@@ -34,53 +31,16 @@ namespace green::impurity {
 
   class impurity_solver {
     using func = std::function<std::tuple<ztensor<3>, ztensor<4>>(
-        size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
+        size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const ztensor<3>& delta_1,
         const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w)>;
 
   public:
     impurity_solver(const green::params::params& p, const grids::transformer_t& ft, const bz_utils_t& bz_utils,
-                    const green_dc_func& dc_func) :
-        _input_file(p["seet_input"]), _root(p["seet_root_dir"]), _spin_symm(p["spin_symm"]), _ft(ft), _bz_utils(bz_utils),
-        _dc_solver(dc_func), _dc_data_prefix(p["dc_data_prefix"])  {
-      size_t        ns = 2;
-      h5pp::archive ar(_input_file, "r");
-      ar["nimp"] >> _nimp;
-      ar.close();
-      if(p["impurity_solver"].as<std::string>() == "ED") {
-        std::shared_ptr<void> ed_solver(new ed_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
-                                                             p["impurity_solver_params"], p["seet_root_dir"]));
-        _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
-                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-          return static_cast<ed_impurity_solver*>(ed_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-        };
-      } else if (p["impurity_solver"].as<std::string>() == "INCHWORM") {
-        if (p["itermax"].as<int>() > 1 && p["mixing_type"].as<std::string>() != "SIGMA_MIXING") {
-          throw std::runtime_error("SEET + inchworm currently only supports itermax = 1 and SIGMA_MIXING mode");
-        }
-        std::shared_ptr<void> inchworm_solver(new inchworm_impurity_solver(p["seet_input"], p["impurity_solver_exec"],
-                                                             p["impurity_solver_params"], p["seet_root_dir"]));
-        _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
-                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-          return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-        };
-      } else if (p["impurity_solver"].as<std::string>() == "GW") {
-        std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
-                                                             p["impurity_solver_params"], _dc_data_prefix, p["seet_root_dir"]));
-        _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
-                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-          return static_cast<gw_impurity_solver*>(gw_solver.get())
-              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-        };
-      }
-    }
+                    const green_dc_func& dc_func);
 
-    auto solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
-               const ztensor<4>& g) const;
+    std::tuple<ztensor<3>, ztensor<4>> solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                                             const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
+                                             const ztensor<4>& g) const;
 
   private:
     std::string                 _input_file;
@@ -93,11 +53,13 @@ namespace green::impurity {
     green_dc_func               _dc_solver;
     std::string                 _dc_data_prefix;
 
-    auto solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const dtensor<4>& interaction,
-                   const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w, const ztensor<4>& g_w) const;
+    std::tuple<ztensor<3>, ztensor<4>> solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                                 const dtensor<4>& interaction, const ztensor<3>& sigma_inf,
+                                                 const ztensor<4>& sigma_w, const ztensor<4>& g_w) const;
 
-    auto extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
-                       const ztensor<4>& sigma_w, const ztensor<4>& g_w) const -> std::tuple<ztensor<3>, ztensor<4>>;
+    std::tuple<ztensor<3>, ztensor<4>> extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                                                     const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
+                                                     const ztensor<4>& g_w) const;
 
     /**
      * Project impurity quantities to active space
@@ -110,167 +72,11 @@ namespace green::impurity {
      * @param UU transformation to active space
      * @return tuple of projected (ovlp, h_core, sigma_inf, g, sigma)
      */
-    auto project_to_as(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
-                       const ztensor<4>& sigma, const ztensor<4>& g,
-                       const ztensor<2>& UU) const -> std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>>;
+    std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>> project_to_as(
+        double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
+        const ztensor<4>& g, const ztensor<2>& UU) const;
   };
 
-  inline auto impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                         const dtensor<4>& interaction, const ztensor<3>& sigma_inf,
-                                         const ztensor<4>& sigma_w, const ztensor<4>& g_w) const {
-    if (!std::filesystem::exists(_root)) {
-      std::filesystem::create_directory(_root);
-    }
-
-    auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
-    return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-  }
-
-  inline auto impurity_solver::extract_delta(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                             const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
-                                             const ztensor<4>& g_w) const -> std::tuple<ztensor<3>, ztensor<4>> {
-    size_t     nw   = g_w.shape()[0];
-    size_t     ns   = g_w.shape()[1];
-    size_t     naso = g_w.shape()[2];
-    ztensor<3> delta_1(h_core.shape());
-    ztensor<4> delta(g_w.shape());
-    for (size_t iw = 0; iw < nw; ++iw) {
-      for (size_t is = 0; is < ns; ++is) {
-        auto g_inv_w_imp = matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) - matrix(sigma_inf(is)) -
-                           matrix(sigma_w(iw, is));
-        auto g_inv_w_loc      = matrix(g_w(iw, is)).inverse().eval();
-        matrix(delta(iw, is)) = g_inv_w_imp - g_inv_w_loc;
-      }
-    }
-    if (_spin_symm) {
-      for (size_t iw = 0; iw < nw; ++iw) {
-        ztensor<2> tmp(naso, naso);
-        for (size_t is = 0; is < ns; ++is) {
-          tmp += delta(iw, is);
-        }
-        tmp /= ns;
-        for (size_t is = 0; is < ns; ++is) delta(iw, is) << tmp;
-      }
-    }
-
-    // extract constant shift in delta
-    grids::MatrixXcd     A(3, 3);
-    grids::MatrixXcd     B(3, 1);
-    std::complex<double> iwn(0.0, -1. / _ft.wsample_fermi()(nw - 1));
-    std::complex<double> iwn1(0.0, -1. / _ft.wsample_fermi()(nw - 2));
-    std::complex<double> iwn2(0.0, -1. / _ft.wsample_fermi()(nw - 3));
-    for (size_t is = 0; is < ns; ++is) {
-      for (size_t io = 0; io < naso; ++io) {
-        for (size_t jo = 0; jo < naso; ++jo) {
-          A << 1.0, iwn, iwn * iwn, 1.0, iwn1, iwn1 * iwn1, 1.0, iwn2, iwn2 * iwn2;
-          B << delta(nw - 1, is, io, jo), delta(nw - 2, is, io, jo), delta(nw - 3, is, io, jo);
-          grids::MatrixXcd X  = A.colPivHouseholderQr().solve(B).eval();
-          delta_1(is, io, jo) = X(0, 0).real();
-        }
-      }
-    }
-    for (size_t iw = 0; iw < nw; ++iw) delta(iw) -= delta_1;
-    return std::make_tuple(delta_1, delta);
-  }
-
-  inline auto impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
-                                     const ztensor<4>& sigma, const ztensor<4>& g) const {
-    size_t     nt = _ft.sd().repn_fermi().nts();
-    size_t     ns = ovlp.shape()[0];
-    ztensor<3> sigma_inf_loc_new(sigma_inf.shape());
-    ztensor<4> sigma_w_loc_new(sigma.shape());
-    utils::mpi_context mpi_ctx(MPI_COMM_SELF);
-    for (int imp = 0; imp < _nimp; ++imp) {
-      // project local quantities onto an active subspace
-      dtensor<2> uu;
-      dtensor<4> interaction;
-      {
-        h5pp::archive ar(_input_file, "r");
-        ar[std::to_string(imp) + "/UU"] >> uu;
-        ar[std::to_string(imp) + "/interaction"] >> interaction;
-        ar.close();
-      }
-      auto [ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as] =
-          project_to_as(mu, ovlp, h_core, sigma_inf, sigma, g, uu.astype<std::complex<double>>());
-      size_t naso = h_core_as.shape()[2];
-      ztensor<4> g_as_w(_ft.sd().repn_fermi().nw(), g_as.shape()[1], g_as.shape()[2], g_as.shape()[3]);
-      ztensor<4> sigma_as_w(_ft.sd().repn_fermi().nw(), sigma_as.shape()[1], sigma_as.shape()[2], sigma_as.shape()[3]);
-      _ft.tau_to_omega(g_as, g_as_w);
-      _ft.tau_to_omega(sigma_as, sigma_as_w);
-      std::array<size_t, 5> shape_in{nt, ns, 1, naso, naso};
-      std::array<size_t, 4> shape_in_inf{ns, 1, naso, naso};
-      std::array<size_t, 4> shape_out{nt, ns, naso, naso};
-      std::array<size_t, 3> shape_out_inf{ns, naso, naso};
-
-      utils::shared_object<ztensor<5>> sigma_dc(shape_in, mpi_ctx);
-      utils::shared_object<ztensor<5>> g_dc(shape_in, mpi_ctx);
-      sigma_dc.fence();
-      sigma_dc.object().set_zero();
-      sigma_dc.fence();
-      g_dc.fence();
-      g_dc.object() << g_as.reshape(shape_in);
-      g_dc.fence();
-
-      // Compute DC self-energy before calling the impurity solver so that
-      // sigma_inf_dc is available for constructing H0_imp = h_core + sigma_inf - sigma_inf_dc
-      ztensor<4> sigma_inf_dc(shape_in_inf);
-      _dc_solver(_dc_data_prefix, imp, g_dc, sigma_inf_dc, sigma_dc);
-
-      // Effective impurity Hamiltonian: H0_imp = h_core + Re(sigma_inf - sigma_inf_dc) (+ delta_1 static hybridization).
-      // The imaginary part is discarded because the ED Hamiltonian must be real; sigma_inf and sigma_inf_dc are
-      // Hermitian so their difference should be real in a proper basis.
-      ztensor<3> sigma_inf_dc_3d(shape_out_inf);
-      sigma_inf_dc_3d << sigma_inf_dc.reshape(shape_out_inf);
-      ztensor<3> hcore_eff_as(h_core_as.shape());
-      for (size_t is = 0; is < h_core_as.shape()[0]; ++is) {
-        matrix(hcore_eff_as(is)) = matrix(h_core_as(is)) +
-            (matrix(sigma_inf_as(is)) - matrix(sigma_inf_dc_3d(is))).real();
-      }
-      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_as, sigma_as_w, g_as_w);
-
-      // Transform impurity solver results from Omega to Tau
-      _ft.omega_to_tau(sigma_w_new, sigma_as);
-
-      // Update impurity results by subtracting DC sigma
-      sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
-      sigma_as -= sigma_dc.object().reshape(shape_out);
-      for (size_t is = 0; is < ns; ++is) {
-        matrix(sigma_inf_loc_new(is)) += matrix(uu).transpose() * matrix(sigma_inf_new(is)) * matrix(uu);
-      }
-      for (size_t it = 0; it < nt; ++it) {
-        for (size_t is = 0; is < ns; ++is) {
-          matrix(sigma_w_loc_new(it, is)) += matrix(uu).transpose() * matrix(sigma_as(it, is)) * matrix(uu);
-        }
-      }
-      std::cout << "Impurity " << imp << " finished" << std::endl;
-    }
-    return std::make_tuple(sigma_inf_loc_new, sigma_w_loc_new);
-  }
-
-  inline auto impurity_solver::project_to_as(
-      double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
-      const ztensor<4>& g, const ztensor<2>& UU) const -> std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>> {
-    size_t     nt   = g.shape()[0];
-    size_t     ns   = ovlp.shape()[0];
-    size_t     naso = UU.shape()[0];
-    ztensor<3> ovlp_as(ns, naso, naso);
-    ztensor<3> h_core_as(ns, naso, naso);
-    ztensor<3> sigma_inf_as(ns, naso, naso);
-    ztensor<4> g_as(nt, ns, naso, naso);
-    ztensor<4> sigma_as(sigma.shape()[0], ns, naso, naso);
-    for (size_t is = 0; is < ns; ++is) {
-      matrix(ovlp_as(is))      = matrix(UU) * matrix(ovlp(is)) * matrix(UU).transpose();
-      matrix(h_core_as(is))    = matrix(UU) * matrix(h_core(is)) * matrix(UU).transpose();
-      matrix(sigma_inf_as(is)) = matrix(UU) * matrix(sigma_inf(is)) * matrix(UU).transpose();
-    }
-    for (size_t it = 0; it < nt; ++it) {
-      for (size_t is = 0; is < ns; ++is) {
-        matrix(g_as(it, is))     = matrix(UU) * matrix(g(it, is)) * matrix(UU).transpose();
-        matrix(sigma_as(it, is)) = matrix(UU) * matrix(sigma(it, is)) * matrix(UU).transpose();
-      }
-    }
-    return std::make_tuple(ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as);
-  }
 }  // namespace green::impurity
 
 #endif  // GREEN_IMPURITY_SOLVER_H

--- a/src/green/impurity/impurity_solver.h
+++ b/src/green/impurity/impurity_solver.h
@@ -22,6 +22,12 @@
 #ifndef GREEN_IMPURITY_SOLVER_H
 #define GREEN_IMPURITY_SOLVER_H
 
+#include <functional>
+#include <tuple>
+
+#include <green/params/params.h>
+#include <green/utils/mpi_shared.h>
+
 #include "common_defs.h"
 
 namespace green::impurity {

--- a/src/green/impurity/inchworm_impurity_solver.h
+++ b/src/green/impurity/inchworm_impurity_solver.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 University of Michigan
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the “Software”), to deal in the Software
+ * software and associated documentation files (the "Software"), to deal in the Software
  * without restriction, including without limitation the rights to use, copy, modify,
  * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to the following
@@ -11,7 +11,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
  * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
@@ -22,188 +22,18 @@
 #ifndef GREEN_INCHWORM_IMPURITY_SOLVER_H
 #define GREEN_INCHWORM_IMPURITY_SOLVER_H
 
+#include "common_defs.h"
+
 namespace green::impurity {
 
   class inchworm_impurity_solver {
-    template <typename prec>
-    using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-    template <typename prec>
-    using CMMatrixX = Eigen::Map<const Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-
   public:
     inchworm_impurity_solver(const std::string& input_file, const std::string& impurity_solver_exec,
-                             const std::string& impurity_solver_params, const std::string& root) :
-        _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
-        _root(root) {
-      h5pp::archive ar(input_file, "r");
-      ar["nimp"] >> _nimp;
-      ar["to_even_tau"] >> _uxl;
-      ar.close();
-    }
+                             const std::string& impurity_solver_params, const std::string& root);
 
-    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-               const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
-      ztensor<3> sigma_inf_new(delta_1.shape());
-      ztensor<4> sigma_new(delta_w.shape());
-      size_t     nio = hcore_eff.shape()[1];
-      size_t     ns  = hcore_eff.shape()[0];
-      bool       rhf = (ns == 1);
-      if (rhf) std::cout << "Detected ns = 1; Assuming this is RHF. Support for relativistic cases not implemented yet." << std::endl;
-      // One-body term
-      // Static:
-      {
-        std::ofstream hooping_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
-        for (size_t i = 0; i < nio; ++i) {
-          for (size_t s1 = 0; s1 < ns; ++s1) {
-            for (size_t j = 0; j < nio; ++j) {
-              for (size_t s2 = 0; s2 < ns; ++s2) {
-                auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
-                hooping_file << i * ns + s1 << " " << j * ns + s2 << " ";
-                if (s1 == s2)
-                  hooping_file << h_imp.real() << " " << h_imp.imag() << "\n";
-                else
-                  hooping_file << 0.0 << " " << 0.0 << "\n";
-              }
-            }
-          }
-        }
-        hooping_file.close();
-      }
-      // Dynamic
-      {
-        auto&                           Tcn = ft.Tcn();
-        CMMatrixX<double>               Ttc_even(_uxl.data(), _uxl.shape()[0], _uxl.shape()[1]);
-        ztensor<4>                      delta_t(_uxl.shape()[0], ns, nio, nio);
-        MMatrixX<std::complex<double>>  delta_t_m(delta_t.data(), _uxl.shape()[0], ns * nio * nio);
-        CMMatrixX<std::complex<double>> delta_w_m(delta_w.data(), delta_w.shape()[0], ns * nio * nio);
-        delta_t_m = Ttc_even * Tcn * delta_w_m * std::sqrt(2.0 / ft.sd().beta());
-        std::ofstream delta_file("imp_" + std::to_string(imp_n) + "_delta.txt");
-        for (size_t t = 0; t < delta_t.shape()[0]; ++t) {
-          for (size_t i = 0; i < nio; ++i) {
-            for (size_t s1 = 0; s1 < ns; ++s1) {
-              for (size_t j = 0; j < nio; ++j) {
-                for (size_t s2 = 0; s2 < ns; ++s2) {
-                  delta_file << t << " " << i * ns + s1 << " " << j * ns + s2 << " ";
-                  if (s1 == s2)
-                    delta_file << delta_t(t, s1, i, j).real() << " " << delta_t(t, s1, i, j).imag() << "\n";
-                  else
-                    delta_file << 0.0 << " " << 0.0 << "\n";
-                }
-              }
-            }
-          }
-        }
-      }
-      // Two-body term with spin symmetry
-      // NOTE: Whether or not we break spin-symmetry in G, or even in x2c relativistic cases, U will still have spin-symmetry.
-      {
-        size_t ndim_increment   = (rhf) ? 1 : 4; // restricted vs unrestricted
-        size_t spin_decrement   = (rhf) ? 0 : 2; // avoid double creation/annihilation in same spin-orbitals
-        size_t non_zero         = 0;
-        for (size_t I = 0; I < nio; ++I) {
-          for (size_t J = 0; J < nio; ++J) {
-            for (size_t K = 0; K < nio; ++K) {
-              for (size_t L = 0; L < nio; ++L) {
-                if (std::abs(interaction(I, J, K, L)) < 1e-10) continue; // forget all logic and skip if interaction is zero
-                if (rhf) {
-                  non_zero += ndim_increment;
-                  continue;
-                }
-                // uhf case
-                // if I == K or J == L, it warrants that the spin label of I and K will be opposite,
-                // and by construction spin of I = spin of J and spin of K = spin of L,
-                // so when (I==K) or (J==L) or both, we need to remove two combinations:
-                // (up up up up) and (dn dn dn dn)
-                non_zero += ndim_increment;
-                if (I == K || J == L) non_zero -= spin_decrement;
-              }
-            }
-          }
-        }
-        std::cout << "------------------------------------------------------------" << std::endl;
-        std::cout << "NOTE: Writing interaction tensor in the all three notations!" << std::endl;
-        std::cout << "1. Chemist notation (imp_" + std::to_string(imp_n) + "_Uijkl_chem.txt): " << std::endl;
-        std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_k c_l c_j" << std::endl;
-        std::cout << "2. Physicist notation (imp_" + std::to_string(imp_n) + "_Uijkl_phys.txt): " << std::endl;
-        std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_j c_l c_k" << std::endl;
-        std::cout << "3. Tensor notation (imp_" + std::to_string(imp_n) + "_Uijkl_cthyb.txt): " << std::endl;
-        std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_j c_k c_l" << std::endl;
-        std::cout << "Use the appropriate file in your workflow." << std::endl;
-        std::cout << "------------------------------------------------------------" << std::endl;
-        std::ofstream U_file_cthyb("imp_" + std::to_string(imp_n) + "_Uijkl_cthyb.txt");
-        std::ofstream U_file_phys("imp_" + std::to_string(imp_n) + "_Uijkl_phys.txt");
-        std::ofstream U_file_chem("imp_" + std::to_string(imp_n) + "_Uijkl_chem.txt");
-        U_file_cthyb << non_zero << "\n";
-        U_file_phys << non_zero << "\n";
-        U_file_chem << non_zero << "\n";
-        size_t idx = 0;
-        for (size_t i = 0; i < nio * ns; ++i) {
-          for (size_t j = 0; j < nio * ns; ++j) {
-            for (size_t k = 0; k < nio * ns; ++k) {
-              for (size_t l = 0; l < nio * ns; ++l) {
-                size_t I = i / ns;
-                size_t J = j / ns;
-                size_t K = k / ns;
-                size_t L = l / ns;
-                // Internally, IJKL and ijkl will be treated as chemist notation indices, i.e.
-                //    i = (I,s1); j = (J,s1); k = (K,s2); l = (L,s2)
-                // When we store to Uijkl.txt, we will re-arrange the indices to match each of the three formats
-
-                // --------------------------------------------------------------
-                // 1. Logic for storing in Physicist notation
-                // --------------------------------------------------------------
-                // We have the tensor notation:    V(ijkl) cdag_i cdag_j c_l c_k
-                // Let's rearrange by changing dummy index labels:
-                //     V(ikjl) cdag_i cdag_k c_l c_j
-                // Compare with:             U(ijkl) cdag_i cdag_k c_l c_j
-                // Therefore,   V(ikjl) = U(ijkl)
-
-                // --------------------------------------------------------------
-                // 2. Logic for storing in Tensor notation
-                // --------------------------------------------------------------
-                // We have the tensor notation:    V(ijkl) cdag_i cdag_j c_k c_l
-                // Let's rearrange by changing dummy index labels:
-                //     V(iklj) cdag_i cdag_k c_l c_j
-                // Compare with:             U(ijkl) cdag_i cdag_k c_l c_j
-                // Therefore,   V(iklj) = U(ijkl)
-                if (std::abs(interaction(I, J, K, L)) < 1e-10) continue;
-                if (rhf) {
-                  U_file_chem << idx << "\t" << i << " " << j << " " << k << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  U_file_phys << idx << "\t" << i << " " << k << " " << j << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  U_file_cthyb << idx << "\t" << i << " " << k << " " << l << " " << j << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  ++idx;
-                } else {
-                  // Deal with spin only for UHF
-                  size_t s1 = i % ns;
-                  size_t s2 = j % ns;
-                  size_t s3 = k % ns;
-                  size_t s4 = l % ns;
-                  if (i == k || j == l) continue;       // ignore double creation/annihilation in same spin-orbitals (different from I,J,K,L which are atomic orbitals)
-                  if (s1 != s2 || s3 != s4) continue;   // ignore spin-flip terms
-                  // what remains is a valid term in Uijkl
-                  U_file_chem << idx << "\t" << i << " " << j << " " << k << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  U_file_phys << idx << "\t" << i << " " << k << " " << j << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  U_file_cthyb << idx << "\t" << i << " " << k << " " << l << " " << j << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
-                  ++idx;
-                }
-              }
-            }
-          }
-        }
-        U_file_cthyb.close();
-        U_file_chem.close();
-        U_file_phys.close();
-      }
-      // Inchworm requires another SLURM job, so we will return ZERO here, and update the actual
-      // result after inchworm calculation is done.
-
-      // std::string run       = (_impurity_solver_exec + " " + _impurity_solver_params);
-      // int         sysresult = std::system(run.c_str());
-      // { std::cerr << "Impurity result file has not been found" << std::endl; }
-      sigma_inf_new.set_zero();
-      sigma_new.set_zero();
-      return std::make_tuple(sigma_inf_new, sigma_new);
-    }
+    std::tuple<ztensor<3>, ztensor<4>> solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp,
+                                             const ztensor<3>& hcore_eff, const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                             const dtensor<4>& interaction, const ztensor<4>& g_w) const;
 
   private:
     std::string _input_file;
@@ -213,5 +43,6 @@ namespace green::impurity {
     size_t      _nimp;
     dtensor<2>  _uxl;
   };
+
 }  // namespace green::impurity
 #endif  // GREEN_INCHWORM_IMPURITY_SOLVER_H

--- a/src/green/impurity/inchworm_impurity_solver.h
+++ b/src/green/impurity/inchworm_impurity_solver.h
@@ -41,12 +41,12 @@ namespace green::impurity {
       ar.close();
     }
 
-    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+    auto solve(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction, const ztensor<4>& g_w) const {
       ztensor<3> sigma_inf_new(delta_1.shape());
       ztensor<4> sigma_new(delta_w.shape());
-      size_t     nio = h_core.shape()[1];
-      size_t     ns  = h_core.shape()[0];
+      size_t     nio = hcore_eff.shape()[1];
+      size_t     ns  = hcore_eff.shape()[0];
       bool       rhf = (ns == 1);
       if (rhf) std::cout << "Detected ns = 1; Assuming this is RHF. Support for relativistic cases not implemented yet." << std::endl;
       // One-body term
@@ -57,7 +57,7 @@ namespace green::impurity {
           for (size_t s1 = 0; s1 < ns; ++s1) {
             for (size_t j = 0; j < nio; ++j) {
               for (size_t s2 = 0; s2 < ns; ++s2) {
-                auto h_imp = h_core(s1, i, j) + delta_1(s1, i, j);
+                auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
                 hooping_file << i * ns + s1 << " " << j * ns + s2 << " ";
                 if (s1 == s2)
                   hooping_file << h_imp.real() << " " << h_imp.imag() << "\n";

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -54,24 +54,6 @@ namespace green::impurity {
     }
   }
 
-  void gw_impurity_solver::write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
-                const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const {
-    h5pp::archive debug_data(_root + "/gw_debug." + std::to_string(imp_n) + ".output.h5", "a");
-    debug_data["bath/mu"] << mu;
-    debug_data["bath/freq"] << ft.wsample_fermi();
-    debug_data["bath/true/ovlp"] << ovlp;
-    debug_data["bath/true/h_core"] << hcore_eff;
-    debug_data["bath/true/g_w"] << g_w;
-    debug_data["bath/true/delta_1"] << delta_1;
-    debug_data["bath/true/delta_w"] << delta_true;
-    debug_data["bath/fit/Epsk"] << Epsk;
-    for (size_t io = 0; io < Vk.size(); ++io) {
-      debug_data["bath/fit/Vk_" + std::to_string(io)] << Vk[io];
-    }
-    debug_data.close();
-  }
-  
   void gw_impurity_solver::prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const ztensor<3>& delta_1,
                 const ztensor<4>& delta_w, const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
                 const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const {

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -1,5 +1,8 @@
-#include <fstream>
+#include <array>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <numeric>
 #include <string>
 #include "green/impurity/gw_impurity_solver.h"
 

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -5,6 +5,114 @@
 
 namespace green::impurity {
 
+  gw_impurity_solver::gw_impurity_solver(const std::string& input_file, const std::string& bath_file,
+                                         const std::string& impurity_solver_exec, const std::string& impurity_solver_params,
+                                         const std::string dc_data_prefix, const std::string& root) :
+      _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
+      _dc_data_prefix(dc_data_prefix), _root(root) {
+    size_t        ns = 2;  // TODO: This is hardcoded - let it be for now
+    size_t        nimp;
+    h5pp::archive ar(input_file, "r");
+    ar["nimp"] >> nimp;
+    ar.close();
+    if (!std::filesystem::exists(bath_file)) throw std::runtime_error("Bath structure file does not exist");
+    std::ifstream ff(bath_file);
+    for (size_t imp = 0; imp < nimp; ++imp) {
+      std::vector<double> bath;
+      std::vector<int>    bath_structure;
+      size_t              nio, nbo;
+      ff >> nio >> nbo;
+      for (size_t io = 0; io < nio; ++io) {
+        int nb_io;
+        ff >> nb_io;
+        bath_structure.push_back(nb_io);
+      }
+      for (size_t bo = 0; bo < nbo * 2; ++bo) {
+        double b;
+        ff >> b;
+        bath.push_back(b);
+      }
+      dtensor<2> initial_bath(ns, bath.size());
+      itensor<1> bath_struct(bath_structure.size());
+      // first spin
+      std::copy(bath.begin(), bath.end(), initial_bath(0).begin());
+      // second spin
+      std::copy(bath.begin(), bath.end(), initial_bath(1).begin());
+      std::copy(bath_structure.begin(), bath_structure.end(), bath_struct.begin());
+      _initial_bath.push_back(initial_bath);
+      _bath_structure.push_back(bath_struct);
+    }
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> gw_impurity_solver::solve(size_t imp_n, const grids::transformer_t& ft, double mu,
+                                                                const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                                                const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                                                const dtensor<4>& interaction, const ztensor<4>& g_w) const {
+    ztensor<3> sigma_inf_new(delta_1.shape());
+    ztensor<4> sigma_new(delta_w.shape());
+
+    // Step 1: Bath fitting and parsing
+    dtensor<2>              Epsk;
+    std::vector<dtensor<2>> Vk;
+    fit_and_parse_bath(imp_n, ft, mu, delta_w, ovlp, Epsk, Vk);
+    // Step 2: Prepare hybrid system and write GW input
+    prepare_gw_input(imp_n, ovlp, hcore_eff, delta_1, delta_w, Epsk, Vk, mu, interaction, g_w, ft);
+
+    size_t      nio = ovlp.shape()[2];
+    size_t      nb  = Epsk.shape()[0];
+    size_t      ns  = Epsk.shape()[1];
+    std::string run = (_impurity_solver_exec +
+                       " --itermax 10 --const_density=false --scf_type=GW --E_thr=1e-5" +
+                       " --mixing_weight=0.7 --restart=true" +
+                       " --BETA=" + std::to_string(ft.sd().beta()) +
+                       " --input_file=" + _root + "/gw." + std::to_string(imp_n) + ".input.h5" +
+                       " --results_file=" + _root + "/gw." + std::to_string(imp_n) + ".sim.h5") +
+                      " --dfintegral_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
+                      " --dfintegral_hf_file=" + _root + "/gw." + std::to_string(imp_n) + ".df_int" +
+                      " " + _impurity_solver_params;
+    std::cout << "\n\n\nWill run the following command!" << std::endl;
+    std::cout << run << std::endl;
+    std::cout << "\n\n\n----" << std::endl;
+    int sysresult = launchCleanChild(run);
+    if (sysresult != 0) {
+      throw std::runtime_error("Impurity GW child process failed with code " + std::to_string(sysresult));
+    }
+    if (std::filesystem::exists(_root + "/gw." + std::to_string(imp_n) + ".sim.h5")) {
+      h5pp::archive ar(_root + "/gw." + std::to_string(imp_n) + ".sim.h5", "r");
+      size_t        it_num;
+      ar["iter"] >> it_num;
+      // Sigma1 is written as complex by sc_loop — read as ztensor, not dtensor.
+      ztensor<4> sigma_inf_imp_plus_bath;
+      ar["iter" + std::to_string(it_num) + "/Sigma1"] >> sigma_inf_imp_plus_bath;
+      for (size_t is = 0; is < ns; ++is) {
+        for (size_t i = 0; i < nio; ++i) {
+          for (size_t j = 0; j < nio; ++j) {
+            sigma_inf_new(is, i, j) = sigma_inf_imp_plus_bath(is, 0, i, j);
+          }
+        }
+      }
+      // Selfenergy/data is stored in tau domain (nt points) by green's sc_loop.
+      // Extract the impurity orbital block and transform tau -> omega before returning.
+      ztensor<5> sigma_tau_imp_plus_bath;
+      ar["iter" + std::to_string(it_num) + "/Selfenergy/data"] >> sigma_tau_imp_plus_bath;
+      size_t     nt_read = sigma_tau_imp_plus_bath.shape()[0];
+      ztensor<4> sigma_tau_imp(nt_read, ns, nio, nio);
+      for (size_t it = 0; it < nt_read; ++it) {
+        for (size_t is = 0; is < ns; ++is) {
+          for (size_t i = 0; i < nio; ++i) {
+            for (size_t j = 0; j < nio; ++j) {
+              sigma_tau_imp(it, is, i, j) = sigma_tau_imp_plus_bath(it, is, 0, i, j);
+            }
+          }
+        }
+      }
+      ft.tau_to_omega(sigma_tau_imp, sigma_new);
+    } else {
+      std::cerr << "Impurity result file has not been found" << std::endl;
+    }
+    return std::make_tuple(sigma_inf_new, sigma_new);
+  }
+
   void gw_impurity_solver::fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
                 dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const {
     // bath fitting

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -1,9 +1,7 @@
-#include <array>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <numeric>
-#include <string>
+#include "green/impurity/bath_fitting.h"
 #include "green/impurity/gw_impurity_solver.h"
 
 namespace green::impurity {
@@ -78,7 +76,7 @@ namespace green::impurity {
     std::cout << "\n\n\n----" << std::endl;
     int sysresult = launchCleanChild(run);
     if (sysresult != 0) {
-      throw std::runtime_error("Impurity GW child process failed with code " + std::to_string(sysresult));
+      throw impurity_solver_exec_error("GW impurity child process failed with code " + std::to_string(sysresult));
     }
     if (std::filesystem::exists(_root + "/gw." + std::to_string(imp_n) + ".sim.h5")) {
       h5pp::archive ar(_root + "/gw." + std::to_string(imp_n) + ".sim.h5", "r");
@@ -111,7 +109,7 @@ namespace green::impurity {
       }
       ft.tau_to_omega(sigma_tau_imp, sigma_new);
     } else {
-      std::cerr << "Impurity result file has not been found" << std::endl;
+      throw impurity_result_not_found("GW impurity result file not found: " + _root + "/gw." + std::to_string(imp_n) + ".sim.h5");
     }
     return std::make_tuple(sigma_inf_new, sigma_new);
   }
@@ -270,7 +268,7 @@ namespace green::impurity {
     }
     ztensor<4> vq_old(chunk_size, naux, nio, nio);
     h5pp::archive int_data_dc(vq_file_dc, "r");
-    int_data_dc["0"] >> reinterpret_cast<double*>(vq_old.data());
+    int_data_dc["0"] >> vq_old.view<double>();
     int_data_dc.close();
     ztensor<4> vq_new(chunk_size, naux, nao_eff, nao_eff);
     vq_new.set_zero();

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -1,0 +1,220 @@
+#include <fstream>
+#include <cstdlib>
+#include <string>
+#include "green/impurity/gw_impurity_solver.h"
+
+namespace green::impurity {
+
+  void gw_impurity_solver::fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
+                dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const {
+    // bath fitting
+    // NOTE: delta_w was extracted at frequency (iw + mu), so the bath fitting must use
+    // shifted frequencies; otherwise the fitted bath energies will be off by ~mu.
+    // The minimize() function fits delta_w(iw) ~ Σ_k V_k^2 / (iw - eps_k)
+    // To match the extraction frequency convention, we pass (iw + mu).
+    auto [delta_out, bath_arr] = minimize(
+      ft.sd().repn_fermi().wsample() * 1.0i, delta_w, _initial_bath[imp_n], _bath_structure[imp_n], 1
+    );
+    // Read results
+    {
+      std::ofstream ofile(_root + "/bath.dat", std::ios_base::out);
+      for (auto b : bath_arr) {
+        ofile << b << " ";
+      }
+      ofile << std::endl;
+    }
+    // Parse output of bath fitting
+    size_t nio = ovlp.shape()[2];
+    size_t ns  = ovlp.shape()[0];
+    size_t nb  = std::reduce(_bath_structure[imp_n].begin(), _bath_structure[imp_n].end());
+    Epsk = dtensor<2>(nb, ns);
+    Vk.clear();
+    for (size_t is = 0; is < ns; ++is) {
+      for (size_t io = 0, ik = 0, shift = 0; io < nio; ++io) {
+        size_t nk = _bath_structure[imp_n](io);
+        for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+          Epsk(ik, is) = bath_arr(is, shift + nk + iik);
+        }
+        shift += 2 * nk;
+      }
+    }
+    for (size_t io = 0; io < nio; ++io) {
+      dtensor<2> Vk_(Epsk.shape());
+      for (size_t io2 = 0, ik = 0, shift = 0; io2 < nio; io2++) {
+        size_t nk = _bath_structure[imp_n](io2);
+        for (size_t iik = 0; iik < nk; ++iik, ++ik) {
+          for (size_t is = 0; is < ns; ++is) {
+            if (io == io2) Vk_(ik, is) = bath_arr(is, shift + iik);
+          }
+        }
+        shift += 2 * nk;
+      }
+      Vk.push_back(Vk_);
+    }
+  }
+
+  void gw_impurity_solver::write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
+                const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const {
+    h5pp::archive debug_data(_root + "/gw_debug." + std::to_string(imp_n) + ".output.h5", "a");
+    debug_data["bath/mu"] << mu;
+    debug_data["bath/freq"] << ft.wsample_fermi();
+    debug_data["bath/true/ovlp"] << ovlp;
+    debug_data["bath/true/h_core"] << h_core;
+    debug_data["bath/true/g_w"] << g_w;
+    debug_data["bath/true/delta_1"] << delta_1;
+    debug_data["bath/true/delta_w"] << delta_true;
+    debug_data["bath/fit/Epsk"] << Epsk;
+    for (size_t io = 0; io < Vk.size(); ++io) {
+      debug_data["bath/fit/Vk_" + std::to_string(io)] << Vk[io];
+    }
+    debug_data.close();
+  }
+  
+  void gw_impurity_solver::prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
+                const ztensor<4>& delta_w, const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
+                const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const {
+    // Step 2: Prepare hybrid system for external GW calculation and write input file
+    size_t nio = ovlp.shape()[2];
+    size_t ns  = ovlp.shape()[0];
+    size_t nb  = Epsk.shape()[0];
+    size_t nao_eff = nb + nio;
+    ztensor<4> h0_eff(ns, 1, nao_eff, nao_eff);
+    ztensor<4> Sk_eff(ns, 1, nao_eff, nao_eff);
+    Sk_eff.set_zero();
+    for (size_t is = 0; is < ns; ++is) {
+      for (size_t i_io = 0; i_io < nio; ++i_io) {
+        // Add hcore as top rows and columns
+        for (size_t j_io = 0; j_io < nio; ++j_io) {
+          h0_eff(is, 0, i_io, j_io) = h_core(is, i_io, j_io) + delta_1(is, i_io, j_io);
+        }
+        h0_eff(is, 0, i_io, i_io) -= mu;
+        // Vk
+        for (size_t j_bo = 0; j_bo < nb; ++j_bo) {
+          h0_eff(is, 0, i_io, nio + j_bo) = Vk[i_io](j_bo, is);
+          h0_eff(is, 0, nio + j_bo, i_io) = Vk[i_io](j_bo, is);
+        }
+      }
+      // eps-k
+      for (size_t j_bo = 0; j_bo < nb; ++j_bo) {
+        h0_eff(is, 0, nio + j_bo, nio + j_bo) = Epsk(j_bo, is);
+      }
+      // Sk-eff -- assuming embedding is in orthogonal basis
+      for (size_t i = 0; i < nao_eff; ++i) {
+        Sk_eff(is, 0, i, i) = std::complex<double>(1.0, 0.0);
+      }
+    }
+
+    // Save to input file
+    std::string gw_input_file = _root + "/gw." + std::to_string(imp_n) + ".input.h5";
+    std::filesystem::copy_file(_dc_data_prefix + "." + std::to_string(imp_n) + "/dummy.h5", gw_input_file,
+                               std::filesystem::copy_options::overwrite_existing);
+    h5pp::archive data(gw_input_file, "a");
+    std::array<size_t, 5> new_shape = {ns, 1, nao_eff, nao_eff, 2};
+    data.set_attribute<std::string>("__green_version__", "0.3.2");  // Set version attribute -- hardwired for now
+    data["HF/H-k"] << h0_eff.view<double>().reshape(new_shape);
+    data["HF/H-k"].set_attribute<int>("__complex__", 1);
+    data["HF/Fock-k"] << h0_eff.view<double>().reshape(new_shape);
+    data["HF/Fock-k"].set_attribute<int>("__complex__", 1);
+    data["HF/S-k"] << Sk_eff.view<double>().reshape(new_shape);
+    data["HF/S-k"].set_attribute<int>("__complex__", 1);
+    data["HF/Energy_nuc"] << 0.0;
+    data["params/nel_cell"] << nio;
+    data["params/ink"] << 1;
+    // determine x2c level
+    int nao_old, nso_old;
+    data["params/nao"] >> nao_old;
+    data["params/nso"] >> nso_old;
+    bool x2c = (nao_old * 2 == nso_old);
+    // update nao and nso
+    data["params/nao"] << nao_eff;
+    data["params/nso"] << (x2c ? 2 * nao_eff : nao_eff);
+    data.close();
+
+    // Sim file for starting Green's function
+    std::string gw_sim_file = _root + "/gw." + std::to_string(imp_n) + ".sim.h5";
+    h5pp::archive sim_data(gw_sim_file, "w");
+    sim_data.set_attribute<std::string>("__grids_version__", ft.get_version());
+    sim_data["iter"] << 1;
+    sim_data["iter1/Energy_1b"] << 0.;
+    sim_data["iter1/Energy_2b"] << 0.;
+    sim_data["iter1/Energy_HF"] << 0.;
+    sim_data["iter1/mu"] << 0.;
+    sim_data.close();
+
+    // Initialize embedded self-energy from Dyson on the impurity block:
+    // Sigma(iw) = (iw+mu)S - h_core - delta_1 - delta_w - G(iw)^{-1}
+    // Keep Sigma1=0 and store full (static + dynamic) contribution in Selfenergy/data.
+    size_t nt = ft.sd().repn_fermi().nts();
+    size_t nw = ft.sd().repn_fermi().nw();
+    ztensor<5> sigma_tau_embed(nt, ns, 1, nao_eff, nao_eff);
+    ztensor<4> sigma_inf_embed(ns, 1, nao_eff, nao_eff);
+    ztensor<5> sigma_iw_embed(nw, ns, 1, nao_eff, nao_eff);
+    sigma_tau_embed.set_zero();
+    sigma_inf_embed.set_zero();
+    sigma_iw_embed.set_zero();
+
+    for (size_t iw = 0; iw < nw; ++iw) {
+      std::complex<double> iwmu = ft.wsample_fermi()(iw) * 1.0i + mu;
+      for (size_t is = 0; is < ns; ++is) {
+        auto g_inv = matrix(g_w(iw, is).copy()).inverse().eval();
+        auto sigma_imp = matrix(ovlp(is)) * iwmu - matrix(h_core(is)) - matrix(delta_1(is)) - matrix(delta_w(iw, is)) - g_inv;
+        for (size_t i = 0; i < nio; ++i) {
+          for (size_t j = 0; j < nio; ++j) {
+            sigma_iw_embed(iw, is, 0, i, j) = sigma_imp(i, j);
+          }
+        }
+      }
+    }
+    ft.omega_to_tau(sigma_iw_embed, sigma_tau_embed);
+
+    h5pp::archive sim_data_append(gw_sim_file, "a");
+    sim_data_append["iter1/Sigma1"] << sigma_inf_embed;
+    sim_data_append["iter1/Selfenergy/data"] << sigma_tau_embed;
+    sim_data_append["iter1/Selfenergy/mesh"] << ft.tau_mesh().points();
+    ztensor<5> g_tau_embed(nt, ns, 1, nao_eff, nao_eff);
+    g_tau_embed.set_zero();
+    sim_data_append["iter1/G_tau/data"] << g_tau_embed;
+    sim_data_append["iter1/G_tau/mesh"] << ft.tau_mesh().points();
+    sim_data_append.close();
+
+    // Interaction Integrals -- we will simply embed the integrals from dc_int to GW output file
+    std::string old_int_dir = _dc_data_prefix + "." + std::to_string(imp_n);
+    std::string vq_file_dc = old_int_dir + "/VQ_0.h5";
+    size_t chunk_size = 0;
+    size_t naux = 0;
+    {
+      h5pp::archive meta_data(old_int_dir + "/meta.h5", "r");
+      meta_data["chunk_size"] >> chunk_size;
+      meta_data.close();
+    }
+    {
+      h5pp::archive dc_input(old_int_dir + "/dummy.h5", "r");
+      dc_input["params/NQ"] >> naux;
+      dc_input.close();
+    }
+    ztensor<4> vq_old(chunk_size, naux, nio, nio);
+    h5pp::archive int_data_dc(vq_file_dc, "r");
+    int_data_dc["0"] >> reinterpret_cast<double*>(vq_old.data());
+    int_data_dc.close();
+    ztensor<4> vq_new(chunk_size, naux, nao_eff, nao_eff);
+    vq_new.set_zero();
+    for (size_t c = 0; c < chunk_size; ++c) {
+      for (size_t q = 0; q < naux; ++q) {
+        for (size_t i = 0; i < nio; ++i) {
+          for (size_t j = 0; j < nio; ++j) {
+            vq_new(c, q, i, j) = vq_old(c, q, i, j);
+          }
+        }
+      }
+    }
+    std::string new_int_dir = _root + "/gw." + std::to_string(imp_n) + ".df_int";
+    std::string new_int_file = new_int_dir +  "/VQ_0.h5";
+    std::filesystem::create_directories(new_int_dir);
+    std::filesystem::copy_file(old_int_dir + "/meta.h5", new_int_dir + "/meta.h5",
+                               std::filesystem::copy_options::overwrite_existing);
+    h5pp::archive int_data_new(new_int_file, "w");
+    int_data_new["0"] << vq_new.view<double>();
+    int_data_new.close();
+  }
+} 

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -268,7 +268,10 @@ namespace green::impurity {
     }
     ztensor<4> vq_old(chunk_size, naux, nio, nio);
     h5pp::archive int_data_dc(vq_file_dc, "r");
-    int_data_dc["0"] >> vq_old.view<double>();
+    // C++11 [complex.numbers] §26.4 guarantees std::complex<T> is layout-compatible with T[2],
+    // so reinterpret_cast<double*> is well-defined and is the correct way to read a flat
+    // double dataset from HDF5 into a complex ndarray without a shape-rank mismatch.
+    int_data_dc["0"] >> reinterpret_cast<double*>(vq_old.data());
     int_data_dc.close();
     ztensor<4> vq_new(chunk_size, naux, nao_eff, nao_eff);
     vq_new.set_zero();

--- a/src/gw_impurity_solver.cpp
+++ b/src/gw_impurity_solver.cpp
@@ -8,10 +8,11 @@ namespace green::impurity {
   void gw_impurity_solver::fit_and_parse_bath(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<4>& delta_w, const ztensor<3>& ovlp,
                 dtensor<2>& Epsk, std::vector<dtensor<2>>& Vk) const {
     // bath fitting
-    // NOTE: delta_w was extracted at frequency (iw + mu), so the bath fitting must use
-    // shifted frequencies; otherwise the fitted bath energies will be off by ~mu.
-    // The minimize() function fits delta_w(iw) ~ Σ_k V_k^2 / (iw - eps_k)
-    // To match the extraction frequency convention, we pass (iw + mu).
+    // minimize() fits delta_w(iw) ~ Σ_k V_k^2 / (iw - eps_k) using bare Matsubara frequencies iw.
+    // This yields fitted bath energies eps_k = eps_k_phys - mu (shifted by -mu relative to physical values).
+    // In prepare_gw_input(), mu is explicitly subtracted from the impurity diagonal of h0_eff, so the
+    // GW solver (which uses frequency iw, not iw+mu) sees the bath propagator (iw - eps_k_fit)^{-1}
+    // = (iw + mu - eps_k_phys)^{-1}, which is correct.
     auto [delta_out, bath_arr] = minimize(
       ft.sd().repn_fermi().wsample() * 1.0i, delta_w, _initial_bath[imp_n], _bath_structure[imp_n], 1
     );
@@ -53,14 +54,14 @@ namespace green::impurity {
     }
   }
 
-  void gw_impurity_solver::write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+  void gw_impurity_solver::write_bath_debug(size_t imp_n, const grids::transformer_t& ft, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
                 const ztensor<3>& delta_1, const ztensor<4>& delta_true, const ztensor<4>& g_w,
                 const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk) const {
     h5pp::archive debug_data(_root + "/gw_debug." + std::to_string(imp_n) + ".output.h5", "a");
     debug_data["bath/mu"] << mu;
     debug_data["bath/freq"] << ft.wsample_fermi();
     debug_data["bath/true/ovlp"] << ovlp;
-    debug_data["bath/true/h_core"] << h_core;
+    debug_data["bath/true/h_core"] << hcore_eff;
     debug_data["bath/true/g_w"] << g_w;
     debug_data["bath/true/delta_1"] << delta_1;
     debug_data["bath/true/delta_w"] << delta_true;
@@ -71,7 +72,7 @@ namespace green::impurity {
     debug_data.close();
   }
   
-  void gw_impurity_solver::prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& delta_1,
+  void gw_impurity_solver::prepare_gw_input(size_t imp_n, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff, const ztensor<3>& delta_1,
                 const ztensor<4>& delta_w, const dtensor<2>& Epsk, const std::vector<dtensor<2>>& Vk, double mu,
                 const dtensor<4>& interaction, const ztensor<4>& g_w, const grids::transformer_t& ft) const {
     // Step 2: Prepare hybrid system for external GW calculation and write input file
@@ -86,7 +87,7 @@ namespace green::impurity {
       for (size_t i_io = 0; i_io < nio; ++i_io) {
         // Add hcore as top rows and columns
         for (size_t j_io = 0; j_io < nio; ++j_io) {
-          h0_eff(is, 0, i_io, j_io) = h_core(is, i_io, j_io) + delta_1(is, i_io, j_io);
+          h0_eff(is, 0, i_io, j_io) = hcore_eff(is, i_io, j_io) + delta_1(is, i_io, j_io);
         }
         h0_eff(is, 0, i_io, i_io) -= mu;
         // Vk
@@ -142,31 +143,12 @@ namespace green::impurity {
     sim_data["iter1/mu"] << 0.;
     sim_data.close();
 
-    // Initialize embedded self-energy from Dyson on the impurity block:
-    // Sigma(iw) = (iw+mu)S - h_core - delta_1 - delta_w - G(iw)^{-1}
-    // Keep Sigma1=0 and store full (static + dynamic) contribution in Selfenergy/data.
+    // Initialize self-energy to zero; the GW impurity solver will build it up self-consistently.
     size_t nt = ft.sd().repn_fermi().nts();
-    size_t nw = ft.sd().repn_fermi().nw();
     ztensor<5> sigma_tau_embed(nt, ns, 1, nao_eff, nao_eff);
     ztensor<4> sigma_inf_embed(ns, 1, nao_eff, nao_eff);
-    ztensor<5> sigma_iw_embed(nw, ns, 1, nao_eff, nao_eff);
     sigma_tau_embed.set_zero();
     sigma_inf_embed.set_zero();
-    sigma_iw_embed.set_zero();
-
-    for (size_t iw = 0; iw < nw; ++iw) {
-      std::complex<double> iwmu = ft.wsample_fermi()(iw) * 1.0i + mu;
-      for (size_t is = 0; is < ns; ++is) {
-        auto g_inv = matrix(g_w(iw, is).copy()).inverse().eval();
-        auto sigma_imp = matrix(ovlp(is)) * iwmu - matrix(h_core(is)) - matrix(delta_1(is)) - matrix(delta_w(iw, is)) - g_inv;
-        for (size_t i = 0; i < nio; ++i) {
-          for (size_t j = 0; j < nio; ++j) {
-            sigma_iw_embed(iw, is, 0, i, j) = sigma_imp(i, j);
-          }
-        }
-      }
-    }
-    ft.omega_to_tau(sigma_iw_embed, sigma_tau_embed);
 
     h5pp::archive sim_data_append(gw_sim_file, "a");
     sim_data_append["iter1/Sigma1"] << sigma_inf_embed;

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -3,6 +3,8 @@
 #include <green/impurity/inchworm_impurity_solver.h>
 #include <green/impurity/gw_impurity_solver.h>
 
+#include <filesystem>
+
 namespace green::impurity {
 
   impurity_solver::impurity_solver(const green::params::params& p, const grids::transformer_t& ft,

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -1,0 +1,208 @@
+#include <green/impurity/impurity_solver.h>
+#include <green/impurity/ed_impurity_solver.h>
+#include <green/impurity/inchworm_impurity_solver.h>
+#include <green/impurity/gw_impurity_solver.h>
+
+namespace green::impurity {
+
+  impurity_solver::impurity_solver(const green::params::params& p, const grids::transformer_t& ft,
+                                   const bz_utils_t& bz_utils, const green_dc_func& dc_func) :
+      _input_file(p["seet_input"]), _root(p["seet_root_dir"]), _spin_symm(p["spin_symm"]), _ft(ft), _bz_utils(bz_utils),
+      _dc_solver(dc_func), _dc_data_prefix(p["dc_data_prefix"]) {
+    h5pp::archive ar(_input_file, "r");
+    ar["nimp"] >> _nimp;
+    ar.close();
+    if (p["impurity_solver"].as<std::string>() == "ED") {
+      std::shared_ptr<void> ed_solver(new ed_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
+                                                             p["impurity_solver_params"], p["seet_root_dir"]));
+      _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                         const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
+                                         const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+        return static_cast<ed_impurity_solver*>(ed_solver.get())
+            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+      };
+    } else if (p["impurity_solver"].as<std::string>() == "INCHWORM") {
+      if (p["itermax"].as<int>() > 1 && p["mixing_type"].as<std::string>() != "SIGMA_MIXING") {
+        throw std::runtime_error("SEET + inchworm currently only supports itermax = 1 and SIGMA_MIXING mode");
+      }
+      std::shared_ptr<void> inchworm_solver(new inchworm_impurity_solver(p["seet_input"], p["impurity_solver_exec"],
+                                                                         p["impurity_solver_params"], p["seet_root_dir"]));
+      _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                               const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                               const dtensor<4>& interaction,
+                                               const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+        return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
+            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+      };
+    } else if (p["impurity_solver"].as<std::string>() == "GW") {
+      std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
+                                                             p["impurity_solver_params"], _dc_data_prefix,
+                                                             p["seet_root_dir"]));
+      _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                         const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
+                                         const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+        return static_cast<gw_impurity_solver*>(gw_solver.get())
+            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+      };
+    }
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp,
+                                                                 const ztensor<3>& hcore_eff, const dtensor<4>& interaction,
+                                                                 const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
+                                                                 const ztensor<4>& g_w) const {
+    if (!std::filesystem::exists(_root)) {
+      std::filesystem::create_directory(_root);
+    }
+    auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
+    return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> impurity_solver::extract_delta(double mu, const ztensor<3>& ovlp,
+                                                                     const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
+                                                                     const ztensor<4>& sigma_w,
+                                                                     const ztensor<4>& g_w) const {
+    size_t     nw   = g_w.shape()[0];
+    size_t     ns   = g_w.shape()[1];
+    size_t     naso = g_w.shape()[2];
+    ztensor<3> delta_1(h_core.shape());
+    ztensor<4> delta(g_w.shape());
+    for (size_t iw = 0; iw < nw; ++iw) {
+      for (size_t is = 0; is < ns; ++is) {
+        auto g_inv_w_imp = matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) -
+                           matrix(sigma_inf(is)) - matrix(sigma_w(iw, is));
+        auto g_inv_w_loc      = matrix(g_w(iw, is)).inverse().eval();
+        matrix(delta(iw, is)) = g_inv_w_imp - g_inv_w_loc;
+      }
+    }
+    if (_spin_symm) {
+      for (size_t iw = 0; iw < nw; ++iw) {
+        ztensor<2> tmp(naso, naso);
+        for (size_t is = 0; is < ns; ++is) {
+          tmp += delta(iw, is);
+        }
+        tmp /= ns;
+        for (size_t is = 0; is < ns; ++is) delta(iw, is) << tmp;
+      }
+    }
+
+    // extract constant shift in delta
+    grids::MatrixXcd     A(3, 3);
+    grids::MatrixXcd     B(3, 1);
+    std::complex<double> iwn(0.0, -1. / _ft.wsample_fermi()(nw - 1));
+    std::complex<double> iwn1(0.0, -1. / _ft.wsample_fermi()(nw - 2));
+    std::complex<double> iwn2(0.0, -1. / _ft.wsample_fermi()(nw - 3));
+    for (size_t is = 0; is < ns; ++is) {
+      for (size_t io = 0; io < naso; ++io) {
+        for (size_t jo = 0; jo < naso; ++jo) {
+          A << 1.0, iwn, iwn * iwn, 1.0, iwn1, iwn1 * iwn1, 1.0, iwn2, iwn2 * iwn2;
+          B << delta(nw - 1, is, io, jo), delta(nw - 2, is, io, jo), delta(nw - 3, is, io, jo);
+          grids::MatrixXcd X  = A.colPivHouseholderQr().solve(B).eval();
+          delta_1(is, io, jo) = X(0, 0).real();
+        }
+      }
+    }
+    for (size_t iw = 0; iw < nw; ++iw) delta(iw) -= delta_1;
+    return std::make_tuple(delta_1, delta);
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
+                                                             const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
+                                                             const ztensor<4>& g) const {
+    size_t     nt = _ft.sd().repn_fermi().nts();
+    size_t     ns = ovlp.shape()[0];
+    ztensor<3> sigma_inf_loc_new(sigma_inf.shape());
+    ztensor<4> sigma_w_loc_new(sigma.shape());
+    utils::mpi_context mpi_ctx(MPI_COMM_SELF);
+    for (int imp = 0; imp < _nimp; ++imp) {
+      dtensor<2> uu;
+      dtensor<4> interaction;
+      {
+        h5pp::archive ar(_input_file, "r");
+        ar[std::to_string(imp) + "/UU"] >> uu;
+        ar[std::to_string(imp) + "/interaction"] >> interaction;
+        ar.close();
+      }
+      auto [ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as] =
+          project_to_as(mu, ovlp, h_core, sigma_inf, sigma, g, uu.astype<std::complex<double>>());
+      size_t     naso = h_core_as.shape()[2];
+      ztensor<4> g_as_w(_ft.sd().repn_fermi().nw(), g_as.shape()[1], g_as.shape()[2], g_as.shape()[3]);
+      ztensor<4> sigma_as_w(_ft.sd().repn_fermi().nw(), sigma_as.shape()[1], sigma_as.shape()[2], sigma_as.shape()[3]);
+      _ft.tau_to_omega(g_as, g_as_w);
+      _ft.tau_to_omega(sigma_as, sigma_as_w);
+      std::array<size_t, 5> shape_in{nt, ns, 1, naso, naso};
+      std::array<size_t, 4> shape_in_inf{ns, 1, naso, naso};
+      std::array<size_t, 4> shape_out{nt, ns, naso, naso};
+      std::array<size_t, 3> shape_out_inf{ns, naso, naso};
+
+      utils::shared_object<ztensor<5>> sigma_dc(shape_in, mpi_ctx);
+      utils::shared_object<ztensor<5>> g_dc(shape_in, mpi_ctx);
+      sigma_dc.fence();
+      sigma_dc.object().set_zero();
+      sigma_dc.fence();
+      g_dc.fence();
+      g_dc.object() << g_as.reshape(shape_in);
+      g_dc.fence();
+
+      // Compute DC self-energy before calling the impurity solver so that
+      // sigma_inf_dc is available for constructing H0_imp = h_core + sigma_inf - sigma_inf_dc
+      ztensor<4> sigma_inf_dc(shape_in_inf);
+      _dc_solver(_dc_data_prefix, imp, g_dc, sigma_inf_dc, sigma_dc);
+
+      // Effective impurity Hamiltonian: H0_imp = h_core + Re(sigma_inf - sigma_inf_dc) (+ delta_1 static hybridization).
+      // The imaginary part is discarded because the ED Hamiltonian must be real; sigma_inf and sigma_inf_dc are
+      // Hermitian so their difference should be real in a proper basis.
+      ztensor<3> sigma_inf_dc_3d(shape_out_inf);
+      sigma_inf_dc_3d << sigma_inf_dc.reshape(shape_out_inf);
+      ztensor<3> hcore_eff_as(h_core_as.shape());
+      for (size_t is = 0; is < h_core_as.shape()[0]; ++is) {
+        matrix(hcore_eff_as(is)) = matrix(h_core_as(is)) +
+            (matrix(sigma_inf_as(is)) - matrix(sigma_inf_dc_3d(is))).real();
+      }
+      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_as, sigma_as_w, g_as_w);
+
+      // Transform impurity solver results from Omega to Tau
+      _ft.omega_to_tau(sigma_w_new, sigma_as);
+
+      // Update impurity results by subtracting DC sigma
+      sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
+      sigma_as -= sigma_dc.object().reshape(shape_out);
+      for (size_t is = 0; is < ns; ++is) {
+        matrix(sigma_inf_loc_new(is)) += matrix(uu).transpose() * matrix(sigma_inf_new(is)) * matrix(uu);
+      }
+      for (size_t it = 0; it < nt; ++it) {
+        for (size_t is = 0; is < ns; ++is) {
+          matrix(sigma_w_loc_new(it, is)) += matrix(uu).transpose() * matrix(sigma_as(it, is)) * matrix(uu);
+        }
+      }
+      std::cout << "Impurity " << imp << " finished" << std::endl;
+    }
+    return std::make_tuple(sigma_inf_loc_new, sigma_w_loc_new);
+  }
+
+  std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>> impurity_solver::project_to_as(
+      double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core, const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
+      const ztensor<4>& g, const ztensor<2>& UU) const {
+    size_t     nt   = g.shape()[0];
+    size_t     ns   = ovlp.shape()[0];
+    size_t     naso = UU.shape()[0];
+    ztensor<3> ovlp_as(ns, naso, naso);
+    ztensor<3> h_core_as(ns, naso, naso);
+    ztensor<3> sigma_inf_as(ns, naso, naso);
+    ztensor<4> g_as(nt, ns, naso, naso);
+    ztensor<4> sigma_as(sigma.shape()[0], ns, naso, naso);
+    for (size_t is = 0; is < ns; ++is) {
+      matrix(ovlp_as(is))      = matrix(UU) * matrix(ovlp(is)) * matrix(UU).transpose();
+      matrix(h_core_as(is))    = matrix(UU) * matrix(h_core(is)) * matrix(UU).transpose();
+      matrix(sigma_inf_as(is)) = matrix(UU) * matrix(sigma_inf(is)) * matrix(UU).transpose();
+    }
+    for (size_t it = 0; it < nt; ++it) {
+      for (size_t is = 0; is < ns; ++is) {
+        matrix(g_as(it, is))     = matrix(UU) * matrix(g(it, is)) * matrix(UU).transpose();
+        matrix(sigma_as(it, is)) = matrix(UU) * matrix(sigma(it, is)) * matrix(UU).transpose();
+      }
+    }
+    return std::make_tuple(ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as);
+  }
+
+}  // namespace green::impurity

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -104,8 +104,8 @@ namespace green::impurity {
   }
 
   std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                                             const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
-                                                             const ztensor<4>& g) const {
+                                                             const ztensor<3>& sigma_inf, const ztensor<3>& sigma_inf_full,
+                                                             const ztensor<4>& sigma, const ztensor<4>& g) const {
     if (!std::filesystem::exists(_root)) {
       std::filesystem::create_directory(_root);
     }
@@ -123,9 +123,19 @@ namespace green::impurity {
         ar[std::to_string(imp) + "/interaction"] >> interaction;
         ar.close();
       }
+      auto uu_c = uu.astype<std::complex<double>>();
       auto [ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as] =
-          project_to_as(mu, ovlp, h_core, sigma_inf, sigma, g, uu.astype<std::complex<double>>());
+          project_to_as(mu, ovlp, h_core, sigma_inf, sigma, g, uu_c);
       size_t     naso = h_core_as.shape()[2];
+
+      // Project the full sigma_inf (weak + impurity corrections from previous iterations)
+      // to the active space. This is passed to extract_delta so the bath hybridization
+      // correctly reflects the previous iteration's impurity correction to the static
+      // self-energy, matching the Python SEET reference where F_act_loc = h_core + sigma_inf_full.
+      ztensor<3> sigma_inf_full_as(ns, naso, naso);
+      for (size_t is = 0; is < ns; ++is) {
+        matrix(sigma_inf_full_as(is)) = matrix(uu_c) * matrix(sigma_inf_full(is)) * matrix(uu_c).transpose();
+      }
       ztensor<4> g_as_w(_ft.sd().repn_fermi().nw(), g_as.shape()[1], g_as.shape()[2], g_as.shape()[3]);
       ztensor<4> sigma_as_w(_ft.sd().repn_fermi().nw(), sigma_as.shape()[1], sigma_as.shape()[2], sigma_as.shape()[3]);
       _ft.tau_to_omega(g_as, g_as_w);
@@ -159,7 +169,11 @@ namespace green::impurity {
         matrix(hcore_eff_as(is)) = matrix(h_core_as(is)) +
             (matrix(sigma_inf_as(is)) - matrix(sigma_inf_dc_3d(is))).real();
       }
-      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_as, sigma_as_w, g_as_w);
+      // Use sigma_inf_full_as (not sigma_inf_as/weak) for extract_delta: the full static
+      // self-energy correctly defines G_imp^{-1} = iw*S + mu - hcore_eff - sigma_inf_full - sigma_w,
+      // matching Python's G0_inv = iw + mu - F_act_loc where F_act_loc includes corrections from
+      // previous impurity iterations. sigma_inf_as (weak) is only used for hcore_eff above.
+      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_full_as, sigma_as_w, g_as_w);
 
       // Transform impurity solver results from Omega to Tau
       _ft.omega_to_tau(sigma_w_new, sigma_as);

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -51,9 +51,6 @@ namespace green::impurity {
                                                                  const ztensor<3>& hcore_eff, const dtensor<4>& interaction,
                                                                  const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
                                                                  const ztensor<4>& g_w) const {
-    if (!std::filesystem::exists(_root)) {
-      std::filesystem::create_directory(_root);
-    }
     auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
     return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
   }
@@ -109,6 +106,9 @@ namespace green::impurity {
   std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
                                                              const ztensor<3>& sigma_inf, const ztensor<4>& sigma,
                                                              const ztensor<4>& g) const {
+    if (!std::filesystem::exists(_root)) {
+      std::filesystem::create_directory(_root);
+    }
     size_t     nt = _ft.sd().repn_fermi().nts();
     size_t     ns = ovlp.shape()[0];
     ztensor<3> sigma_inf_loc_new(sigma_inf.shape());

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -47,29 +47,23 @@ namespace green::impurity {
     }
   }
 
-  std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve_imp(size_t imp_n, double mu, const ztensor<3>& ovlp,
-                                                                 const ztensor<3>& hcore_eff, const dtensor<4>& interaction,
-                                                                 const ztensor<3>& sigma_inf, const ztensor<4>& sigma_w,
-                                                                 const ztensor<4>& g_w) const {
-    auto [delta_1, delta_w] = extract_delta(mu, ovlp, hcore_eff, sigma_inf, sigma_w, g_w);
-    return _impurity_call(imp_n, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-  }
-
   std::tuple<ztensor<3>, ztensor<4>> impurity_solver::extract_delta(double mu, const ztensor<3>& ovlp,
-                                                                     const ztensor<3>& h_core, const ztensor<3>& sigma_inf,
+                                                                     const ztensor<3>& fock_act_loc,
                                                                      const ztensor<4>& sigma_w,
                                                                      const ztensor<4>& g_w) const {
     size_t     nw   = g_w.shape()[0];
     size_t     ns   = g_w.shape()[1];
     size_t     naso = g_w.shape()[2];
-    ztensor<3> delta_1(h_core.shape());
+    ztensor<3> delta_1(fock_act_loc.shape());
     ztensor<4> delta(g_w.shape());
     for (size_t iw = 0; iw < nw; ++iw) {
       for (size_t is = 0; is < ns; ++is) {
-        auto g_inv_w_imp = matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) - matrix(h_core(is)) -
-                           matrix(sigma_inf(is)) - matrix(sigma_w(iw, is));
-        auto g_inv_w_loc      = matrix(g_w(iw, is)).inverse().eval();
-        matrix(delta(iw, is)) = g_inv_w_imp - g_inv_w_loc;
+        // G_imp^{-1}(iw) = (iw + mu)*S - F_act_loc - Sigma_w
+        // F_act_loc = h_core + sigma_inf_full  (matches Python's F_act_loc = h_core + Sigma1_full)
+        auto g_inv_imp        = matrix(ovlp(is)) * (_ft.wsample_fermi()(iw) * 1.0i + mu) -
+                                matrix(fock_act_loc(is)) - matrix(sigma_w(iw, is));
+        auto g_inv_loc        = matrix(g_w(iw, is)).inverse().eval();
+        matrix(delta(iw, is)) = g_inv_imp - g_inv_loc;
       }
     }
     if (_spin_symm) {
@@ -83,7 +77,7 @@ namespace green::impurity {
       }
     }
 
-    // extract constant shift in delta
+    // Extract the static (iw -> inf) offset of delta by fitting the three largest Matsubara points
     grids::MatrixXcd     A(3, 3);
     grids::MatrixXcd     B(3, 1);
     std::complex<double> iwn(0.0, -1. / _ft.wsample_fermi()(nw - 1));
@@ -104,16 +98,19 @@ namespace green::impurity {
   }
 
   std::tuple<ztensor<3>, ztensor<4>> impurity_solver::solve(double mu, const ztensor<3>& ovlp, const ztensor<3>& h_core,
-                                                             const ztensor<3>& sigma_inf, const ztensor<3>& sigma_inf_full,
+                                                             const ztensor<3>& sigma_inf_weak,
+                                                             const ztensor<3>& sigma_inf_full,
                                                              const ztensor<4>& sigma, const ztensor<4>& g) const {
     if (!std::filesystem::exists(_root)) {
       std::filesystem::create_directory(_root);
     }
-    size_t     nt = _ft.sd().repn_fermi().nts();
-    size_t     ns = ovlp.shape()[0];
-    ztensor<3> sigma_inf_loc_new(sigma_inf.shape());
-    ztensor<4> sigma_w_loc_new(sigma.shape());
+    size_t     nt  = _ft.sd().repn_fermi().nts();
+    size_t     nw  = _ft.sd().repn_fermi().nw();
+    size_t     ns  = ovlp.shape()[0];
+    ztensor<3> sigma_inf_imp_loc(sigma_inf_weak.shape());
+    ztensor<4> sigma_tau_imp_loc(sigma.shape());
     utils::mpi_context mpi_ctx(MPI_COMM_SELF);
+
     for (int imp = 0; imp < _nimp; ++imp) {
       dtensor<2> uu;
       dtensor<4> interaction;
@@ -124,74 +121,73 @@ namespace green::impurity {
         ar.close();
       }
       auto uu_c = uu.astype<std::complex<double>>();
-      auto [ovlp_as, h_core_as, sigma_inf_as, g_as, sigma_as] =
-          project_to_as(mu, ovlp, h_core, sigma_inf, sigma, g, uu_c);
-      size_t     naso = h_core_as.shape()[2];
 
-      // Project the full sigma_inf (weak + impurity corrections from previous iterations)
-      // to the active space. This is passed to extract_delta so the bath hybridization
-      // correctly reflects the previous iteration's impurity correction to the static
-      // self-energy, matching the Python SEET reference where F_act_loc = h_core + sigma_inf_full.
+      // --- Project all quantities to the active space (AS) ---
+      auto [ovlp_as, h_core_as, sigma_inf_weak_as, g_as, sigma_as] =
+          project_to_as(mu, ovlp, h_core, sigma_inf_weak, sigma, g, uu_c);
+      size_t naso = h_core_as.shape()[2];
+
       ztensor<3> sigma_inf_full_as(ns, naso, naso);
-      for (size_t is = 0; is < ns; ++is) {
+      for (size_t is = 0; is < ns; ++is)
         matrix(sigma_inf_full_as(is)) = matrix(uu_c) * matrix(sigma_inf_full(is)) * matrix(uu_c).transpose();
-      }
-      ztensor<4> g_as_w(_ft.sd().repn_fermi().nw(), g_as.shape()[1], g_as.shape()[2], g_as.shape()[3]);
-      ztensor<4> sigma_as_w(_ft.sd().repn_fermi().nw(), sigma_as.shape()[1], sigma_as.shape()[2], sigma_as.shape()[3]);
+
+      // --- Fourier transform G and Sigma from tau to Matsubara ---
+      ztensor<4> g_as_w(nw, ns, naso, naso);
+      ztensor<4> sigma_as_w(nw, ns, naso, naso);
       _ft.tau_to_omega(g_as, g_as_w);
       _ft.tau_to_omega(sigma_as, sigma_as_w);
-      std::array<size_t, 5> shape_in{nt, ns, 1, naso, naso};
-      std::array<size_t, 4> shape_in_inf{ns, 1, naso, naso};
-      std::array<size_t, 4> shape_out{nt, ns, naso, naso};
-      std::array<size_t, 3> shape_out_inf{ns, naso, naso};
 
-      utils::shared_object<ztensor<5>> sigma_dc(shape_in, mpi_ctx);
-      utils::shared_object<ztensor<5>> g_dc(shape_in, mpi_ctx);
-      sigma_dc.fence();
-      sigma_dc.object().set_zero();
-      sigma_dc.fence();
-      g_dc.fence();
-      g_dc.object() << g_as.reshape(shape_in);
-      g_dc.fence();
+      // --- Compute double-counting (DC) self-energy ---
+      std::array<size_t, 5> shape5{nt, ns, 1, naso, naso};
+      std::array<size_t, 4> shape4_inf{ns, 1, naso, naso};
+      utils::shared_object<ztensor<5>> sigma_dc(shape5, mpi_ctx);
+      utils::shared_object<ztensor<5>> g_dc(shape5, mpi_ctx);
+      sigma_dc.fence(); sigma_dc.object().set_zero(); sigma_dc.fence();
+      g_dc.fence(); g_dc.object() << g_as.reshape(shape5); g_dc.fence();
 
-      // Compute DC self-energy before calling the impurity solver so that
-      // sigma_inf_dc is available for constructing H0_imp = h_core + sigma_inf - sigma_inf_dc
-      ztensor<4> sigma_inf_dc(shape_in_inf);
+      ztensor<4> sigma_inf_dc(shape4_inf);
       _dc_solver(_dc_data_prefix, imp, g_dc, sigma_inf_dc, sigma_dc);
 
-      // Effective impurity Hamiltonian: H0_imp = h_core + Re(sigma_inf - sigma_inf_dc) (+ delta_1 static hybridization).
-      // The imaginary part is discarded because the ED Hamiltonian must be real; sigma_inf and sigma_inf_dc are
-      // Hermitian so their difference should be real in a proper basis.
-      ztensor<3> sigma_inf_dc_3d(shape_out_inf);
-      sigma_inf_dc_3d << sigma_inf_dc.reshape(shape_out_inf);
+      std::array<size_t, 3> shape3{ns, naso, naso};
+      std::array<size_t, 4> shape4{nt, ns, naso, naso};
+      ztensor<3> sigma_inf_dc_as(shape3);
+      sigma_inf_dc_as << sigma_inf_dc.reshape(shape3);
+
+      // --- Impurity Hamiltonian: H0_imp = h_core + Re(sigma_inf_weak - sigma_inf_dc) ---
+      // The real part is taken because H0 must be Hermitian for ED; sigma_inf_weak and
+      // sigma_inf_dc are Hermitian so their difference is real in a proper basis.
       ztensor<3> hcore_eff_as(h_core_as.shape());
-      for (size_t is = 0; is < h_core_as.shape()[0]; ++is) {
+      for (size_t is = 0; is < ns; ++is)
         matrix(hcore_eff_as(is)) = matrix(h_core_as(is)) +
-            (matrix(sigma_inf_as(is)) - matrix(sigma_inf_dc_3d(is))).real();
-      }
-      // Use sigma_inf_full_as (not sigma_inf_as/weak) for extract_delta: the full static
-      // self-energy correctly defines G_imp^{-1} = iw*S + mu - hcore_eff - sigma_inf_full - sigma_w,
-      // matching Python's G0_inv = iw + mu - F_act_loc where F_act_loc includes corrections from
-      // previous impurity iterations. sigma_inf_as (weak) is only used for hcore_eff above.
-      auto [sigma_inf_new, sigma_w_new] = solve_imp(imp, mu, ovlp_as, hcore_eff_as, interaction, sigma_inf_full_as, sigma_as_w, g_as_w);
+            (matrix(sigma_inf_weak_as(is)) - matrix(sigma_inf_dc_as(is))).real();
 
-      // Transform impurity solver results from Omega to Tau
-      _ft.omega_to_tau(sigma_w_new, sigma_as);
+      // --- Bath hybridization ---
+      // F_act_loc = h_core + sigma_inf_full  (matches Python's F_act_loc)
+      // G_imp^{-1}(iw) = (iw + mu)*S - F_act_loc - Sigma_w  =>  Delta = G_imp^{-1} - G_loc^{-1}
+      ztensor<3> fock_act_loc_as(h_core_as.shape());
+      for (size_t is = 0; is < ns; ++is)
+        matrix(fock_act_loc_as(is)) = matrix(h_core_as(is)) + matrix(sigma_inf_full_as(is));
 
-      // Update impurity results by subtracting DC sigma
-      sigma_inf_new -= sigma_inf_dc.reshape(shape_out_inf);
-      sigma_as -= sigma_dc.object().reshape(shape_out);
-      for (size_t is = 0; is < ns; ++is) {
-        matrix(sigma_inf_loc_new(is)) += matrix(uu).transpose() * matrix(sigma_inf_new(is)) * matrix(uu);
-      }
-      for (size_t it = 0; it < nt; ++it) {
-        for (size_t is = 0; is < ns; ++is) {
-          matrix(sigma_w_loc_new(it, is)) += matrix(uu).transpose() * matrix(sigma_as(it, is)) * matrix(uu);
-        }
-      }
+      auto [delta_1, delta_w] = extract_delta(mu, ovlp_as, fock_act_loc_as, sigma_as_w, g_as_w);
+
+      // --- Solve the impurity problem ---
+      auto [sigma_inf_imp_as, sigma_w_imp_as] =
+          _impurity_call(imp, mu, ovlp_as, hcore_eff_as, delta_1, delta_w, interaction, g_as_w);
+
+      // --- Subtract DC and back-project to the full space ---
+      _ft.omega_to_tau(sigma_w_imp_as, sigma_as);
+      sigma_inf_imp_as -= sigma_inf_dc_as;
+      sigma_as -= sigma_dc.object().reshape(shape4);
+
+      for (size_t is = 0; is < ns; ++is)
+        matrix(sigma_inf_imp_loc(is)) += matrix(uu).transpose() * matrix(sigma_inf_imp_as(is)) * matrix(uu);
+      for (size_t it = 0; it < nt; ++it)
+        for (size_t is = 0; is < ns; ++is)
+          matrix(sigma_tau_imp_loc(it, is)) += matrix(uu).transpose() * matrix(sigma_as(it, is)) * matrix(uu);
+
       std::cout << "Impurity " << imp << " finished" << std::endl;
     }
-    return std::make_tuple(sigma_inf_loc_new, sigma_w_loc_new);
+    return std::make_tuple(sigma_inf_imp_loc, sigma_tau_imp_loc);
   }
 
   std::tuple<ztensor<3>, ztensor<3>, ztensor<3>, ztensor<4>, ztensor<4>> impurity_solver::project_to_as(

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -53,6 +53,8 @@ namespace green::impurity {
         };
         break;
       }
+      // No default: parse_impurity_solver_type() throws incorr_impurity_solver_type
+      // for any unrecognised value before this switch is reached.
     }
   }
 

--- a/src/impurity_solver.cpp
+++ b/src/impurity_solver.cpp
@@ -14,38 +14,45 @@ namespace green::impurity {
     h5pp::archive ar(_input_file, "r");
     ar["nimp"] >> _nimp;
     ar.close();
-    if (p["impurity_solver"].as<std::string>() == "ED") {
-      std::shared_ptr<void> ed_solver(new ed_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
-                                                             p["impurity_solver_params"], p["seet_root_dir"]));
-      _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                         const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
-                                         const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-        return static_cast<ed_impurity_solver*>(ed_solver.get())
-            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-      };
-    } else if (p["impurity_solver"].as<std::string>() == "INCHWORM") {
-      if (p["itermax"].as<int>() > 1 && p["mixing_type"].as<std::string>() != "SIGMA_MIXING") {
-        throw std::runtime_error("SEET + inchworm currently only supports itermax = 1 and SIGMA_MIXING mode");
+    switch (parse_impurity_solver_type(p["impurity_solver"].as<std::string>())) {
+      case impurity_solver_type::ED: {
+        std::shared_ptr<void> ed_solver(new ed_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
+                                                               p["impurity_solver_params"], p["seet_root_dir"]));
+        _impurity_call = [ed_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
+                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+          return static_cast<ed_impurity_solver*>(ed_solver.get())
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+        };
+        break;
       }
-      std::shared_ptr<void> inchworm_solver(new inchworm_impurity_solver(p["seet_input"], p["impurity_solver_exec"],
-                                                                         p["impurity_solver_params"], p["seet_root_dir"]));
-      _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                               const ztensor<3>& delta_1, const ztensor<4>& delta_w,
-                                               const dtensor<4>& interaction,
-                                               const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-        return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
-            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-      };
-    } else if (p["impurity_solver"].as<std::string>() == "GW") {
-      std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
-                                                             p["impurity_solver_params"], _dc_data_prefix,
-                                                             p["seet_root_dir"]));
-      _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
-                                         const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
-                                         const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
-        return static_cast<gw_impurity_solver*>(gw_solver.get())
-            ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
-      };
+      case impurity_solver_type::INCHWORM: {
+        if (p["itermax"].as<int>() > 1 && p["mixing_type"].as<std::string>() != "SIGMA_MIXING") {
+          throw std::runtime_error("SEET + inchworm currently only supports itermax = 1 and SIGMA_MIXING mode");
+        }
+        std::shared_ptr<void> inchworm_solver(new inchworm_impurity_solver(p["seet_input"], p["impurity_solver_exec"],
+                                                                           p["impurity_solver_params"], p["seet_root_dir"]));
+        _impurity_call = [inchworm_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                                 const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                                 const dtensor<4>& interaction,
+                                                 const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+          return static_cast<inchworm_impurity_solver*>(inchworm_solver.get())
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+        };
+        break;
+      }
+      case impurity_solver_type::GW: {
+        std::shared_ptr<void> gw_solver(new gw_impurity_solver(p["seet_input"], p["bath_file"], p["impurity_solver_exec"],
+                                                               p["impurity_solver_params"], _dc_data_prefix,
+                                                               p["seet_root_dir"]));
+        _impurity_call = [gw_solver, this](size_t imp_n, double mu, const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                           const ztensor<3>& delta_1, const ztensor<4>& delta_w, const dtensor<4>& interaction,
+                                           const ztensor<4>& g_w) -> std::tuple<ztensor<3>, ztensor<4>> {
+          return static_cast<gw_impurity_solver*>(gw_solver.get())
+              ->solve(imp_n, _ft, mu, ovlp, hcore_eff, delta_1, delta_w, interaction, g_w);
+        };
+        break;
+      }
     }
   }
 
@@ -104,7 +111,7 @@ namespace green::impurity {
                                                              const ztensor<3>& sigma_inf_full,
                                                              const ztensor<4>& sigma, const ztensor<4>& g) const {
     if (!std::filesystem::exists(_root)) {
-      std::filesystem::create_directory(_root);
+      std::filesystem::create_directories(_root);
     }
     size_t     nt  = _ft.sd().repn_fermi().nts();
     size_t     nw  = _ft.sd().repn_fermi().nw();

--- a/src/inchworm_impurity_solver.cpp
+++ b/src/inchworm_impurity_solver.cpp
@@ -29,22 +29,22 @@ namespace green::impurity {
     // One-body term
     // Static:
     {
-      std::ofstream hopping_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
+      std::ofstream onebody_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
       for (size_t i = 0; i < nio; ++i) {
         for (size_t s1 = 0; s1 < ns; ++s1) {
           for (size_t j = 0; j < nio; ++j) {
             for (size_t s2 = 0; s2 < ns; ++s2) {
               auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
-              hopping_file << i * ns + s1 << " " << j * ns + s2 << " ";
+              onebody_file << i * ns + s1 << " " << j * ns + s2 << " ";
               if (s1 == s2)
-                hopping_file << h_imp.real() << " " << h_imp.imag() << "\n";
+                onebody_file << h_imp.real() << " " << h_imp.imag() << "\n";
               else
-                hopping_file << 0.0 << " " << 0.0 << "\n";
+                onebody_file << 0.0 << " " << 0.0 << "\n";
             }
           }
         }
       }
-      hopping_file.close();
+      onebody_file.close();
     }
     // Dynamic
     {

--- a/src/inchworm_impurity_solver.cpp
+++ b/src/inchworm_impurity_solver.cpp
@@ -29,22 +29,22 @@ namespace green::impurity {
     // One-body term
     // Static:
     {
-      std::ofstream hooping_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
+      std::ofstream hopping_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
       for (size_t i = 0; i < nio; ++i) {
         for (size_t s1 = 0; s1 < ns; ++s1) {
           for (size_t j = 0; j < nio; ++j) {
             for (size_t s2 = 0; s2 < ns; ++s2) {
               auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
-              hooping_file << i * ns + s1 << " " << j * ns + s2 << " ";
+              hopping_file << i * ns + s1 << " " << j * ns + s2 << " ";
               if (s1 == s2)
-                hooping_file << h_imp.real() << " " << h_imp.imag() << "\n";
+                hopping_file << h_imp.real() << " " << h_imp.imag() << "\n";
               else
-                hooping_file << 0.0 << " " << 0.0 << "\n";
+                hopping_file << 0.0 << " " << 0.0 << "\n";
             }
           }
         }
       }
-      hooping_file.close();
+      hopping_file.close();
     }
     // Dynamic
     {

--- a/src/inchworm_impurity_solver.cpp
+++ b/src/inchworm_impurity_solver.cpp
@@ -2,6 +2,8 @@
 
 #include <fstream>
 #include <iostream>
+#include <iomanip>
+#include <limits>
 
 namespace green::impurity {
 
@@ -30,11 +32,12 @@ namespace green::impurity {
     // Static:
     {
       std::ofstream onebody_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
+      onebody_file << std::setprecision(std::numeric_limits<double>::max_digits10);
       for (size_t i = 0; i < nio; ++i) {
         for (size_t s1 = 0; s1 < ns; ++s1) {
           for (size_t j = 0; j < nio; ++j) {
             for (size_t s2 = 0; s2 < ns; ++s2) {
-              auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
+              auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j) - mu * ovlp(s1, i, j);
               onebody_file << i * ns + s1 << " " << j * ns + s2 << " ";
               if (s1 == s2)
                 onebody_file << h_imp.real() << " " << h_imp.imag() << "\n";
@@ -55,6 +58,7 @@ namespace green::impurity {
       CMMatrixXcd delta_w_m(delta_w.data(), delta_w.shape()[0], ns * nio * nio);
       delta_t_m = Ttc_even * Tcn * delta_w_m * std::sqrt(2.0 / ft.sd().beta());
       std::ofstream delta_file("imp_" + std::to_string(imp_n) + "_delta.txt");
+      delta_file << std::setprecision(std::numeric_limits<double>::max_digits10);
       for (size_t t = 0; t < delta_t.shape()[0]; ++t) {
         for (size_t i = 0; i < nio; ++i) {
           for (size_t s1 = 0; s1 < ns; ++s1) {
@@ -110,6 +114,9 @@ namespace green::impurity {
       std::ofstream U_file_cthyb("imp_" + std::to_string(imp_n) + "_Uijkl_cthyb.txt");
       std::ofstream U_file_phys("imp_" + std::to_string(imp_n) + "_Uijkl_phys.txt");
       std::ofstream U_file_chem("imp_" + std::to_string(imp_n) + "_Uijkl_chem.txt");
+      U_file_cthyb << std::setprecision(std::numeric_limits<double>::max_digits10);
+      U_file_phys  << std::setprecision(std::numeric_limits<double>::max_digits10);
+      U_file_chem  << std::setprecision(std::numeric_limits<double>::max_digits10);
       U_file_cthyb << non_zero << "\n";
       U_file_phys << non_zero << "\n";
       U_file_chem << non_zero << "\n";

--- a/src/inchworm_impurity_solver.cpp
+++ b/src/inchworm_impurity_solver.cpp
@@ -1,0 +1,177 @@
+#include <green/impurity/inchworm_impurity_solver.h>
+
+#include <fstream>
+#include <iostream>
+
+namespace green::impurity {
+
+  inchworm_impurity_solver::inchworm_impurity_solver(const std::string& input_file, const std::string& impurity_solver_exec,
+                                                     const std::string& impurity_solver_params, const std::string& root) :
+      _input_file(input_file), _impurity_solver_exec(impurity_solver_exec), _impurity_solver_params(impurity_solver_params),
+      _root(root) {
+    h5pp::archive ar(input_file, "r");
+    ar["nimp"] >> _nimp;
+    ar["to_even_tau"] >> _uxl;
+    ar.close();
+  }
+
+  std::tuple<ztensor<3>, ztensor<4>> inchworm_impurity_solver::solve(size_t imp_n, const grids::transformer_t& ft, double mu,
+                                                                      const ztensor<3>& ovlp, const ztensor<3>& hcore_eff,
+                                                                      const ztensor<3>& delta_1, const ztensor<4>& delta_w,
+                                                                      const dtensor<4>& interaction,
+                                                                      const ztensor<4>& g_w) const {
+    ztensor<3> sigma_inf_new(delta_1.shape());
+    ztensor<4> sigma_new(delta_w.shape());
+    size_t     nio = hcore_eff.shape()[1];
+    size_t     ns  = hcore_eff.shape()[0];
+    bool       rhf = (ns == 1);
+    if (rhf) std::cout << "Detected ns = 1; Assuming this is RHF. Support for relativistic cases not implemented yet." << std::endl;
+    // One-body term
+    // Static:
+    {
+      std::ofstream hooping_file("imp_" + std::to_string(imp_n) + "_hopping.txt");
+      for (size_t i = 0; i < nio; ++i) {
+        for (size_t s1 = 0; s1 < ns; ++s1) {
+          for (size_t j = 0; j < nio; ++j) {
+            for (size_t s2 = 0; s2 < ns; ++s2) {
+              auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j);
+              hooping_file << i * ns + s1 << " " << j * ns + s2 << " ";
+              if (s1 == s2)
+                hooping_file << h_imp.real() << " " << h_imp.imag() << "\n";
+              else
+                hooping_file << 0.0 << " " << 0.0 << "\n";
+            }
+          }
+        }
+      }
+      hooping_file.close();
+    }
+    // Dynamic
+    {
+      auto&      Tcn       = ft.Tcn();
+      CMMatrixXd Ttc_even(_uxl.data(), _uxl.shape()[0], _uxl.shape()[1]);
+      ztensor<4> delta_t(_uxl.shape()[0], ns, nio, nio);
+      MMatrixXcd delta_t_m(delta_t.data(), _uxl.shape()[0], ns * nio * nio);
+      CMMatrixXcd delta_w_m(delta_w.data(), delta_w.shape()[0], ns * nio * nio);
+      delta_t_m = Ttc_even * Tcn * delta_w_m * std::sqrt(2.0 / ft.sd().beta());
+      std::ofstream delta_file("imp_" + std::to_string(imp_n) + "_delta.txt");
+      for (size_t t = 0; t < delta_t.shape()[0]; ++t) {
+        for (size_t i = 0; i < nio; ++i) {
+          for (size_t s1 = 0; s1 < ns; ++s1) {
+            for (size_t j = 0; j < nio; ++j) {
+              for (size_t s2 = 0; s2 < ns; ++s2) {
+                delta_file << t << " " << i * ns + s1 << " " << j * ns + s2 << " ";
+                if (s1 == s2)
+                  delta_file << delta_t(t, s1, i, j).real() << " " << delta_t(t, s1, i, j).imag() << "\n";
+                else
+                  delta_file << 0.0 << " " << 0.0 << "\n";
+              }
+            }
+          }
+        }
+      }
+    }
+    // Two-body term with spin symmetry
+    // NOTE: Whether or not we break spin-symmetry in G, or even in x2c relativistic cases, U will still have spin-symmetry.
+    {
+      size_t ndim_increment = (rhf) ? 1 : 4;  // restricted vs unrestricted
+      size_t spin_decrement = (rhf) ? 0 : 2;  // avoid double creation/annihilation in same spin-orbitals
+      size_t non_zero       = 0;
+      for (size_t I = 0; I < nio; ++I) {
+        for (size_t J = 0; J < nio; ++J) {
+          for (size_t K = 0; K < nio; ++K) {
+            for (size_t L = 0; L < nio; ++L) {
+              if (std::abs(interaction(I, J, K, L)) < 1e-10) continue;
+              if (rhf) {
+                non_zero += ndim_increment;
+                continue;
+              }
+              // uhf case
+              // if I == K or J == L, it warrants that the spin label of I and K will be opposite,
+              // and by construction spin of I = spin of J and spin of K = spin of L,
+              // so when (I==K) or (J==L) or both, we need to remove two combinations:
+              // (up up up up) and (dn dn dn dn)
+              non_zero += ndim_increment;
+              if (I == K || J == L) non_zero -= spin_decrement;
+            }
+          }
+        }
+      }
+      std::cout << "------------------------------------------------------------" << std::endl;
+      std::cout << "NOTE: Writing interaction tensor in the all three notations!" << std::endl;
+      std::cout << "1. Chemist notation (imp_" + std::to_string(imp_n) + "_Uijkl_chem.txt): " << std::endl;
+      std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_k c_l c_j" << std::endl;
+      std::cout << "2. Physicist notation (imp_" + std::to_string(imp_n) + "_Uijkl_phys.txt): " << std::endl;
+      std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_j c_l c_k" << std::endl;
+      std::cout << "3. Tensor notation (imp_" + std::to_string(imp_n) + "_Uijkl_cthyb.txt): " << std::endl;
+      std::cout << "\t 2-body term = (1/2) * U(ijkl) cdag_i cdag_j c_k c_l" << std::endl;
+      std::cout << "Use the appropriate file in your workflow." << std::endl;
+      std::cout << "------------------------------------------------------------" << std::endl;
+      std::ofstream U_file_cthyb("imp_" + std::to_string(imp_n) + "_Uijkl_cthyb.txt");
+      std::ofstream U_file_phys("imp_" + std::to_string(imp_n) + "_Uijkl_phys.txt");
+      std::ofstream U_file_chem("imp_" + std::to_string(imp_n) + "_Uijkl_chem.txt");
+      U_file_cthyb << non_zero << "\n";
+      U_file_phys << non_zero << "\n";
+      U_file_chem << non_zero << "\n";
+      size_t idx = 0;
+      for (size_t i = 0; i < nio * ns; ++i) {
+        for (size_t j = 0; j < nio * ns; ++j) {
+          for (size_t k = 0; k < nio * ns; ++k) {
+            for (size_t l = 0; l < nio * ns; ++l) {
+              size_t I = i / ns;
+              size_t J = j / ns;
+              size_t K = k / ns;
+              size_t L = l / ns;
+              // --------------------------------------------------------------
+              // 1. Logic for storing in Physicist notation
+              // --------------------------------------------------------------
+              // We have the tensor notation:    V(ijkl) cdag_i cdag_j c_l c_k
+              // Let's rearrange by changing dummy index labels:
+              //     V(ikjl) cdag_i cdag_k c_l c_j
+              // Compare with:             U(ijkl) cdag_i cdag_k c_l c_j
+              // Therefore,   V(ikjl) = U(ijkl)
+
+              // --------------------------------------------------------------
+              // 2. Logic for storing in Tensor notation
+              // --------------------------------------------------------------
+              // We have the tensor notation:    V(ijkl) cdag_i cdag_j c_k c_l
+              // Let's rearrange by changing dummy index labels:
+              //     V(iklj) cdag_i cdag_k c_l c_j
+              // Compare with:             U(ijkl) cdag_i cdag_k c_l c_j
+              // Therefore,   V(iklj) = U(ijkl)
+              if (std::abs(interaction(I, J, K, L)) < 1e-10) continue;
+              if (rhf) {
+                U_file_chem << idx << "\t" << i << " " << j << " " << k << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                U_file_phys << idx << "\t" << i << " " << k << " " << j << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                U_file_cthyb << idx << "\t" << i << " " << k << " " << l << " " << j << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                ++idx;
+              } else {
+                // Deal with spin only for UHF
+                size_t s1 = i % ns;
+                size_t s2 = j % ns;
+                size_t s3 = k % ns;
+                size_t s4 = l % ns;
+                if (i == k || j == l) continue;      // ignore double creation/annihilation in same spin-orbitals
+                if (s1 != s2 || s3 != s4) continue;  // ignore spin-flip terms
+                // what remains is a valid term in Uijkl
+                U_file_chem << idx << "\t" << i << " " << j << " " << k << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                U_file_phys << idx << "\t" << i << " " << k << " " << j << " " << l << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                U_file_cthyb << idx << "\t" << i << " " << k << " " << l << " " << j << " " << interaction(I, J, K, L) << " " << 0.0 << "\n";
+                ++idx;
+              }
+            }
+          }
+        }
+      }
+      U_file_cthyb.close();
+      U_file_chem.close();
+      U_file_phys.close();
+    }
+    // Inchworm requires another SLURM job, so we will return ZERO here, and update the actual
+    // result after inchworm calculation is done.
+    sigma_inf_new.set_zero();
+    sigma_new.set_zero();
+    return std::make_tuple(sigma_inf_new, sigma_new);
+  }
+
+}  // namespace green::impurity

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,9 +15,12 @@ list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 add_executable(bath_fitting_test bath_fitting_test.cpp )
 target_compile_definitions(bath_fitting_test PRIVATE TEST_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data"
         GRID_PATH="${grids_SOURCE_DIR}/data")
+find_program(TRUE_EXECUTABLE true REQUIRED)
+
 add_executable(impurity_test impurity_solver_test.cpp )
 target_compile_definitions(impurity_test PRIVATE TEST_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data"
-        GRID_PATH="${grids_SOURCE_DIR}/data")
+        GRID_PATH="${grids_SOURCE_DIR}/data"
+        TRUE_EXECUTABLE="${TRUE_EXECUTABLE}")
 target_link_libraries(bath_fitting_test PRIVATE Catch2::Catch2WithMain GREEN::IMPURITY)
 target_link_libraries(impurity_test PRIVATE Catch2::Catch2 GREEN::IMPURITY)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,10 +17,18 @@ target_compile_definitions(bath_fitting_test PRIVATE TEST_PATH="${CMAKE_CURRENT_
         GRID_PATH="${grids_SOURCE_DIR}/data")
 find_program(TRUE_EXECUTABLE true REQUIRED)
 
+# Fake ED impurity solver: writes zero-valued result files so the ED test can
+# exercise the full solver path without depending on an external executable.
+add_executable(ed_test ed_test.cpp)
+target_link_libraries(ed_test PRIVATE GREEN::IMPURITY)
+
 add_executable(impurity_test impurity_solver_test.cpp )
 target_compile_definitions(impurity_test PRIVATE TEST_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data"
+        TEST_OUTPUT_PATH="${CMAKE_CURRENT_BINARY_DIR}/impurity_test_output"
         GRID_PATH="${grids_SOURCE_DIR}/data"
-        TRUE_EXECUTABLE="${TRUE_EXECUTABLE}")
+        TRUE_EXECUTABLE="${TRUE_EXECUTABLE}"
+        ED_FAKE_EXECUTABLE="$<TARGET_FILE:ed_test>")
+add_dependencies(impurity_test ed_test)
 target_link_libraries(bath_fitting_test PRIVATE Catch2::Catch2WithMain GREEN::IMPURITY)
 target_link_libraries(impurity_test PRIVATE Catch2::Catch2 GREEN::IMPURITY)
 

--- a/test/ed_test.cpp
+++ b/test/ed_test.cpp
@@ -1,0 +1,62 @@
+/*
+ * Fake ED impurity solver used by the impurity_solver test suite.
+ *
+ * Mimics the command-line contract of the real ED solver: reads --INPUT_FILE=<path>
+ * and --OUTPUT_FILE=<path>, determines the required output shapes from the input
+ * file, and writes zero-valued results/Sigma_inf_ij and results/Sigma_ij so that
+ * ed_impurity_solver::solve() can read them back and return normally.
+ *
+ * Using a real helper binary (instead of pre-seeding the output file from the
+ * test body) exercises the full solver code path: command construction, child
+ * process launch, and post-run read.
+ */
+
+#include <green/h5pp/archive.h>
+#include <green/impurity/common_defs.h>
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  std::string input_file;
+  std::string output_file;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    auto        eq = arg.find('=');
+    if (eq == std::string::npos) continue;
+    std::string key = arg.substr(0, eq);
+    std::string val = arg.substr(eq + 1);
+    if (key == "--INPUT_FILE") input_file = val;
+    else if (key == "--OUTPUT_FILE") output_file = val;
+  }
+  if (input_file.empty() || output_file.empty()) {
+    std::cerr << "ed_test: required args --INPUT_FILE=<path> --OUTPUT_FILE=<path>" << std::endl;
+    return 1;
+  }
+
+  // Derive (ns, naso, nw) from the input file written by ed_impurity_solver.
+  green::impurity::ztensor<3> delta_static;
+  green::impurity::ztensor<4> delta_in;
+  {
+    green::h5pp::archive ar(input_file, "r");
+    ar["Delta/static"] >> delta_static;
+    ar["Delta/data_in"] >> delta_in;
+    ar.close();
+  }
+  size_t ns   = delta_static.shape()[0];
+  size_t naso = delta_static.shape()[1];
+  size_t nw   = delta_in.shape()[0];
+
+  green::impurity::dtensor<3> sigma_inf(ns, naso, naso);
+  green::impurity::ztensor<4> sigma_w(nw, ns, naso, naso);
+  sigma_inf.set_zero();
+  sigma_w.set_zero();
+
+  green::h5pp::archive out(output_file, "w");
+  out["results/Sigma_inf_ij"] << sigma_inf;
+  // ed_impurity_solver reads Sigma_ij via sigma_new.view<double>() (last dim doubled);
+  // write through the same view so on-disk shape matches the read side.
+  out["results/Sigma_ij"] << sigma_w.view<double>();
+  out.close();
+  return 0;
+}

--- a/test/impurity_solver_test.cpp
+++ b/test/impurity_solver_test.cpp
@@ -147,6 +147,11 @@ TEST_CASE("Impurity Solver") {
       REQUIRE(interaction.shape()[2] == 2);
       REQUIRE(interaction.shape()[3] == 2);
     }
+    // Cleanup
+    for (int imp = 0; imp < 2; ++imp) {
+      std::filesystem::remove(TEST_PATH + "/ed."s + std::to_string(imp) + ".input.h5");
+    }
+    std::filesystem::remove(TEST_PATH + "/bath.dat"s);
   }
 
   SECTION("INCHWORM") {

--- a/test/impurity_solver_test.cpp
+++ b/test/impurity_solver_test.cpp
@@ -58,7 +58,8 @@ namespace green::impurity {
   }
 }
 
-void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_prefix = "") {
+void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_prefix = "",
+                          std::string impurity_solver_exec = TRUE_EXECUTABLE) {
   std::string test_file   = TEST_PATH + "/data.h5"s;
   std::string bath_file   = TEST_PATH + "/bath.txt"s;
   std::string input_file   = TEST_PATH + "/transform.h5"s;
@@ -71,10 +72,10 @@ void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_
   p.define<bool>("spin_symm", "", false);
   p.define<std::string>("bath_file", "", bath_file);
   p.define<std::string>("impurity_solver", "", impurity_solver_type);
-  p.define<std::string>("impurity_solver_exec", "", TRUE_EXECUTABLE);
+  p.define<std::string>("impurity_solver_exec", "", impurity_solver_exec);
   p.define<std::string>("impurity_solver_params", "", "");
   p.define<std::string>("dc_data_prefix", "", dc_data_prefix);
-  p.define<std::string>("seet_root_dir", "", TEST_PATH + ""s);
+  p.define<std::string>("seet_root_dir", "", TEST_OUTPUT_PATH + ""s);
   p.define<std::string>("seet_input", "", input_file);
   if (impurity_solver_type == "INCHWORM") {
     p.define<std::string>("itermax", "", "1");
@@ -128,13 +129,21 @@ void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_
 }
 
 TEST_CASE("Impurity Solver") {
+  // All solver output goes to a dedicated scratch directory in the build tree,
+  // so the source-tree test/data/ fixtures are never mutated.
+  std::filesystem::remove_all(TEST_OUTPUT_PATH);
+  std::filesystem::create_directories(TEST_OUTPUT_PATH);
+
   SECTION("ED") {
-    impurity_solver_test("ED");
+    // ED_FAKE_EXECUTABLE is a tiny helper (test/ed_test.cpp) that writes
+    // zero-valued results/Sigma_{inf_ij,ij} so the solver's post-run read
+    // succeeds and the full solver code path is exercised.
+    impurity_solver_test("ED", "", ED_FAKE_EXECUTABLE);
     // Verify that ed.{imp}.input.h5 was written with correct structure.
     // nb=8 for imp 0 (bath_structure=[4,4]), nb=4 for imp 1 (bath_structure=[2,2]), nio=2 for both.
     const std::array<size_t, 2> expected_nb = {8, 4};
     for (int imp = 0; imp < 2; ++imp) {
-      std::string ed_file = TEST_PATH + "/ed."s + std::to_string(imp) + ".input.h5";
+      std::string ed_file = TEST_OUTPUT_PATH + "/ed."s + std::to_string(imp) + ".input.h5";
       REQUIRE(std::filesystem::exists(ed_file));
       green::h5pp::archive ar(ed_file, "r");
       // Bath discretization: Epsk has shape (nb, ns)
@@ -147,11 +156,7 @@ TEST_CASE("Impurity Solver") {
       REQUIRE(interaction.shape()[2] == 2);
       REQUIRE(interaction.shape()[3] == 2);
     }
-    // Cleanup
-    for (int imp = 0; imp < 2; ++imp) {
-      std::filesystem::remove(TEST_PATH + "/ed."s + std::to_string(imp) + ".input.h5");
-    }
-    std::filesystem::remove(TEST_PATH + "/bath.dat"s);
+    std::filesystem::remove_all(TEST_OUTPUT_PATH);
   }
 
   SECTION("INCHWORM") {
@@ -297,7 +302,7 @@ TEST_CASE("Impurity Solver") {
     // Both impurities have nio=2; we use naux=1 and chunk_size=1 to keep fixtures small.
     // The GW solver reads: dummy.h5 (params/nao, params/nso, params/NQ),
     //   meta.h5 (chunk_size), VQ_0.h5 ("0": chunk_size*naux*nio*nio complex doubles).
-    std::string dc_prefix = TEST_PATH + "/dc"s;
+    std::string dc_prefix = TEST_OUTPUT_PATH + "/dc"s;
     for (int imp = 0; imp < 2; ++imp) {
       std::string dc_dir = dc_prefix + "." + std::to_string(imp);
       std::filesystem::create_directories(dc_dir);
@@ -325,7 +330,7 @@ TEST_CASE("Impurity Solver") {
     // nao_eff = nio + nb: imp 0 has nb=8 -> nao_eff=10; imp 1 has nb=4 -> nao_eff=6.
     const std::array<size_t, 2> expected_nao_eff = {10, 6};
     for (int imp = 0; imp < 2; ++imp) {
-      std::string prefix = TEST_PATH + "/gw."s + std::to_string(imp);
+      std::string prefix = TEST_OUTPUT_PATH + "/gw."s + std::to_string(imp);
       REQUIRE(std::filesystem::exists(prefix + ".input.h5"));
       REQUIRE(std::filesystem::exists(prefix + ".sim.h5"));
 
@@ -357,14 +362,20 @@ TEST_CASE("Impurity Solver") {
       }
     }
 
-    // Cleanup
-    for (int imp = 0; imp < 2; ++imp) {
-      std::filesystem::remove_all(dc_prefix + "." + std::to_string(imp));
-      std::string prefix = TEST_PATH + "/gw."s + std::to_string(imp);
-      std::filesystem::remove(prefix + ".input.h5");
-      std::filesystem::remove(prefix + ".sim.h5");
-      std::filesystem::remove_all(prefix + ".df_int");
-    }
+    std::filesystem::remove_all(TEST_OUTPUT_PATH);
+  }
+
+  SECTION("Exception Handling") {
+    // Unknown impurity_solver string: parse_impurity_solver_type() throws
+    // incorr_impurity_solver_type from the impurity_solver constructor before
+    // any child process is launched.
+    REQUIRE_THROWS_AS(impurity_solver_test("XYZ"), green::impurity::incorr_impurity_solver_type);
+    // Use some random executable (does not exist) to run ED solver
+    // should throw an error in execution
+    REQUIRE_THROWS_AS(impurity_solver_test("ED", "", "abc.exe"), green::impurity::impurity_solver_exec_error);
+    // Use /bin/true
+    // a legit executable that runs correctly, but does not generate output
+    REQUIRE_THROWS_AS(impurity_solver_test("ED", ""), green::impurity::impurity_result_not_found);
   }
 }
 

--- a/test/impurity_solver_test.cpp
+++ b/test/impurity_solver_test.cpp
@@ -71,7 +71,7 @@ void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_
   p.define<bool>("spin_symm", "", false);
   p.define<std::string>("bath_file", "", bath_file);
   p.define<std::string>("impurity_solver", "", impurity_solver_type);
-  p.define<std::string>("impurity_solver_exec", "", "/bin/true");
+  p.define<std::string>("impurity_solver_exec", "", TRUE_EXECUTABLE);
   p.define<std::string>("impurity_solver_params", "", "");
   p.define<std::string>("dc_data_prefix", "", dc_data_prefix);
   p.define<std::string>("seet_root_dir", "", TEST_PATH + ""s);

--- a/test/impurity_solver_test.cpp
+++ b/test/impurity_solver_test.cpp
@@ -58,7 +58,7 @@ namespace green::impurity {
   }
 }
 
-void impurity_solver_test(std::string impurity_solver_type) {
+void impurity_solver_test(std::string impurity_solver_type, std::string dc_data_prefix = "") {
   std::string test_file   = TEST_PATH + "/data.h5"s;
   std::string bath_file   = TEST_PATH + "/bath.txt"s;
   std::string input_file   = TEST_PATH + "/transform.h5"s;
@@ -73,7 +73,7 @@ void impurity_solver_test(std::string impurity_solver_type) {
   p.define<std::string>("impurity_solver", "", impurity_solver_type);
   p.define<std::string>("impurity_solver_exec", "", "/bin/true");
   p.define<std::string>("impurity_solver_params", "", "");
-  p.define<std::string>("dc_data_prefix", "", "");
+  p.define<std::string>("dc_data_prefix", "", dc_data_prefix);
   p.define<std::string>("seet_root_dir", "", TEST_PATH + ""s);
   p.define<std::string>("seet_input", "", input_file);
   if (impurity_solver_type == "INCHWORM") {
@@ -124,11 +124,31 @@ void impurity_solver_test(std::string impurity_solver_type) {
   auto h_core = green::impurity::compute_local_obj(h_core_k, x_k, bz_utils, ns, nso, false);
   auto sigma1 = green::impurity::compute_local_obj(sigma1_k, x_k, bz_utils, ns, nso);
 
-  solver.solve(mu, ovlp, h_core, sigma1, sigma, g);
+  solver.solve(mu, ovlp, h_core, sigma1, sigma1, sigma, g);
 }
 
 TEST_CASE("Impurity Solver") {
-  SECTION("ED") { impurity_solver_test("ED"); }
+  SECTION("ED") {
+    impurity_solver_test("ED");
+    // Verify that ed.{imp}.input.h5 was written with correct structure.
+    // nb=8 for imp 0 (bath_structure=[4,4]), nb=4 for imp 1 (bath_structure=[2,2]), nio=2 for both.
+    const std::array<size_t, 2> expected_nb = {8, 4};
+    for (int imp = 0; imp < 2; ++imp) {
+      std::string ed_file = TEST_PATH + "/ed."s + std::to_string(imp) + ".input.h5";
+      REQUIRE(std::filesystem::exists(ed_file));
+      green::h5pp::archive ar(ed_file, "r");
+      // Bath discretization: Epsk has shape (nb, ns)
+      green::impurity::dtensor<2> epsk;
+      ar["Bath/Epsk/values"] >> epsk;
+      REQUIRE(epsk.shape()[0] == expected_nb[imp]);
+      // Interaction tensor: shape (2, 2, nio, nio, nio, nio), nio=2
+      green::impurity::dtensor<6> interaction;
+      ar["interaction/values"] >> interaction;
+      REQUIRE(interaction.shape()[2] == 2);
+      REQUIRE(interaction.shape()[3] == 2);
+    }
+  }
+
   SECTION("INCHWORM") {
     impurity_solver_test("INCHWORM");
     // Check if Hamiltonian data files were created successfully for all impurities
@@ -265,6 +285,81 @@ TEST_CASE("Impurity Solver") {
     std::filesystem::remove("imp_1_Uijkl_chem.txt");
     std::filesystem::remove("imp_1_Uijkl_phys.txt");
     std::filesystem::remove("imp_1_Uijkl_cthyb.txt");
+  }
+
+  SECTION("GW") {
+    // Create minimal DC integral fixture files for each impurity.
+    // Both impurities have nio=2; we use naux=1 and chunk_size=1 to keep fixtures small.
+    // The GW solver reads: dummy.h5 (params/nao, params/nso, params/NQ),
+    //   meta.h5 (chunk_size), VQ_0.h5 ("0": chunk_size*naux*nio*nio complex doubles).
+    std::string dc_prefix = TEST_PATH + "/dc"s;
+    for (int imp = 0; imp < 2; ++imp) {
+      std::string dc_dir = dc_prefix + "." + std::to_string(imp);
+      std::filesystem::create_directories(dc_dir);
+      {
+        green::h5pp::archive ar(dc_dir + "/dummy.h5", "w");
+        ar["params/nao"] << (int)2;
+        ar["params/nso"] << (int)2;
+        ar["params/NQ"]  << (size_t)1;
+      }
+      {
+        green::h5pp::archive ar(dc_dir + "/meta.h5", "w");
+        ar["chunk_size"] << (size_t)1;
+      }
+      {
+        // 1 chunk * 1 aux * 2 orb * 2 orb = 4 complex<double> = 8 doubles
+        green::h5pp::archive ar(dc_dir + "/VQ_0.h5", "w");
+        std::vector<double> zeros(8, 0.0);
+        ar["0"] << zeros;
+      }
+    }
+
+    impurity_solver_test("GW", dc_prefix);
+
+    // Verify that gw.{imp}.input.h5 and gw.{imp}.sim.h5 were written for each impurity.
+    // nao_eff = nio + nb: imp 0 has nb=8 -> nao_eff=10; imp 1 has nb=4 -> nao_eff=6.
+    const std::array<size_t, 2> expected_nao_eff = {10, 6};
+    for (int imp = 0; imp < 2; ++imp) {
+      std::string prefix = TEST_PATH + "/gw."s + std::to_string(imp);
+      REQUIRE(std::filesystem::exists(prefix + ".input.h5"));
+      REQUIRE(std::filesystem::exists(prefix + ".sim.h5"));
+
+      // H-k in the GW input file covers the full impurity+bath system
+      {
+        green::h5pp::archive ar(prefix + ".input.h5", "r");
+        green::impurity::dtensor<5> hk;
+        ar["HF/H-k"] >> hk;
+        REQUIRE(hk.shape()[2] == expected_nao_eff[imp]);
+        REQUIRE(hk.shape()[3] == expected_nao_eff[imp]);
+      }
+
+      // Sim file: self-energy must be zero-initialized and have the right orbital dimension
+      {
+        green::h5pp::archive ar(prefix + ".sim.h5", "r");
+        size_t iter;
+        ar["iter"] >> iter;
+        REQUIRE(iter == 1);
+        green::impurity::ztensor<4> sigma_inf;
+        ar["iter1/Sigma1"] >> sigma_inf;
+        REQUIRE(sigma_inf.shape()[2] == expected_nao_eff[imp]);
+        REQUIRE(sigma_inf.shape()[3] == expected_nao_eff[imp]);
+        bool all_zero = true;
+        for (size_t is = 0; is < sigma_inf.shape()[0] && all_zero; ++is)
+          for (size_t i = 0; i < sigma_inf.shape()[2] && all_zero; ++i)
+            for (size_t j = 0; j < sigma_inf.shape()[3] && all_zero; ++j)
+              if (std::abs(sigma_inf(is, 0, i, j)) > 1e-15) all_zero = false;
+        REQUIRE(all_zero);
+      }
+    }
+
+    // Cleanup
+    for (int imp = 0; imp < 2; ++imp) {
+      std::filesystem::remove_all(dc_prefix + "." + std::to_string(imp));
+      std::string prefix = TEST_PATH + "/gw."s + std::to_string(imp);
+      std::filesystem::remove(prefix + ".input.h5");
+      std::filesystem::remove(prefix + ".sim.h5");
+      std::filesystem::remove_all(prefix + ".df_int");
+    }
   }
 }
 


### PR DESCRIPTION
This is a relatively big PR, but the diffs are large only because of restructuring of the files. Overall, three key changes are made:
1. Redistribution of class definitions to different header files for better readability and debugging,
2. Bug fix: in the definition of `H0` for the impurity system, previously it was
    ```bash
    # INCORRECT
    H0_imp = h_core + Delta_inf
    ```
    This has been updated to
    ```bash
    # CORRECT
    H0_imp = h_core + Sigma_inf_weak - Sigma_inf_DC + Delta_inf
    ```
3. Adding scGW as a new impurity solver.

This PR makes the code SEET framework functional, but subsequent clean up will be posted in a follow-up PR.